### PR TITLE
Make shared log files readable while in use

### DIFF
--- a/src/Serilog.Sinks.File/Sinks/File/FileSink.cs
+++ b/src/Serilog.Sinks.File/Sinks/File/FileSink.cs
@@ -14,9 +14,6 @@
 
 using System;
 using System.IO;
-#if ATOMIC_APPEND
-using System.Security.AccessControl;
-#endif
 using System.Text;
 using Serilog.Core;
 using Serilog.Events;
@@ -64,13 +61,7 @@ namespace Serilog.Sinks.File
                 Directory.CreateDirectory(directory);
             }
 
-#if ATOMIC_APPEND
-            // FileSystemRights.AppendData improves performance substantially (~30%) when available.
-            Stream file = new FileStream(path, FileMode.Append, FileSystemRights.AppendData, FileShare.Read, 4096, FileOptions.None);
-#else
             Stream file = System.IO.File.Open(path, FileMode.Append, FileAccess.Write, FileShare.Read);
-#endif
-
             if (_fileSizeLimitBytes != null)
             {
                 file = _countingStreamWrapper = new WriteCountingStream(file);

--- a/src/Serilog.Sinks.File/Sinks/File/SharedFileSink.cs
+++ b/src/Serilog.Sinks.File/Sinks/File/SharedFileSink.cs
@@ -75,7 +75,7 @@ namespace Serilog.Sinks.File
                 path, 
                 FileMode.Append,
                 FileSystemRights.AppendData,
-                FileShare.Write,
+                FileShare.ReadWrite,
                 _fileStreamBufferLength,
                 FileOptions.None);
 
@@ -118,7 +118,7 @@ namespace Serilog.Sinks.File
                             _path,
                             FileMode.Append,
                             FileSystemRights.AppendData,
-                            FileShare.Write,
+                            FileShare.ReadWrite,
                             length,
                             FileOptions.None);
                         _fileStreamBufferLength = length;


### PR DESCRIPTION
Missed the `FileShare.Read` option in the original implementation :-O

Fixes https://github.com/serilog/serilog-sinks-rollingfile/issues/20
