### PR TITLE
Flush to disk option

### DIFF
--- a/src/Serilog.Sinks.File/FileLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.File/FileLoggerConfigurationExtensions.cs
@@ -48,6 +48,7 @@ namespace Serilog
         /// <param name="buffered">Indicates if flushing to the output file can be buffered or not. The default
         /// is false.</param>
         /// <param name="shared">Allow the log file to be shared by multiple processes. The default is false.</param>
+        /// <param name="flushToDiskInterval">If provided, a full disk flush will be performed periodically at the specified interval.</param>
         /// <returns>Configuration object allowing method chaining.</returns>
         /// <remarks>The file will be written using the UTF-8 character set.</remarks>
         public static LoggerConfiguration File(
@@ -59,14 +60,15 @@ namespace Serilog
             long? fileSizeLimitBytes = DefaultFileSizeLimitBytes,
             LoggingLevelSwitch levelSwitch = null,
             bool buffered = false,
-            bool shared = false)
+            bool shared = false,
+            TimeSpan? flushToDiskInterval = null)
         {
             if (sinkConfiguration == null) throw new ArgumentNullException(nameof(sinkConfiguration));
             if (path == null) throw new ArgumentNullException(nameof(path));
             if (outputTemplate == null) throw new ArgumentNullException(nameof(outputTemplate));
 
             var formatter = new MessageTemplateTextFormatter(outputTemplate, formatProvider);
-            return File(sinkConfiguration, formatter, path, restrictedToMinimumLevel, fileSizeLimitBytes, levelSwitch, buffered: buffered, shared: shared);
+            return File(sinkConfiguration, formatter, path, restrictedToMinimumLevel, fileSizeLimitBytes, levelSwitch, buffered: buffered, shared: shared, flushToDiskInterval: flushToDiskInterval);
         }
 
         /// <summary>
@@ -75,7 +77,7 @@ namespace Serilog
         /// <param name="sinkConfiguration">Logger sink configuration.</param>
         /// <param name="formatter">A formatter, such as <see cref="JsonFormatter"/>, to convert the log events into
         /// text for the file. If control of regular text formatting is required, use the other
-        /// overload of <see cref="File(LoggerSinkConfiguration, string, LogEventLevel, string, IFormatProvider, long?, LoggingLevelSwitch, bool, bool)"/>
+        /// overload of <see cref="File(LoggerSinkConfiguration, string, LogEventLevel, string, IFormatProvider, long?, LoggingLevelSwitch, bool, bool, TimeSpan?)"/>
         /// and specify the outputTemplate parameter instead.
         /// </param>
         /// <param name="path">Path to the file.</param>
@@ -89,6 +91,7 @@ namespace Serilog
         /// <param name="buffered">Indicates if flushing to the output file can be buffered or not. The default
         /// is false.</param>
         /// <param name="shared">Allow the log file to be shared by multiple processes. The default is false.</param>
+        /// <param name="flushToDiskInterval">If provided, a full disk flush will be performed periodically at the specified interval.</param>
         /// <returns>Configuration object allowing method chaining.</returns>
         /// <remarks>The file will be written using the UTF-8 character set.</remarks>
         public static LoggerConfiguration File(
@@ -99,9 +102,10 @@ namespace Serilog
             long? fileSizeLimitBytes = DefaultFileSizeLimitBytes,
             LoggingLevelSwitch levelSwitch = null,
             bool buffered = false,
-            bool shared = false)
+            bool shared = false,
+            TimeSpan? flushToDiskInterval = null)
         {
-            return ConfigureFile(sinkConfiguration.Sink, formatter, path, restrictedToMinimumLevel, fileSizeLimitBytes, levelSwitch, buffered: buffered, shared: shared);
+            return ConfigureFile(sinkConfiguration.Sink, formatter, path, restrictedToMinimumLevel, fileSizeLimitBytes, levelSwitch, buffered: buffered, shared: shared, flushToDiskInterval: flushToDiskInterval);
         }
 
         /// <summary>
@@ -169,7 +173,8 @@ namespace Serilog
             LoggingLevelSwitch levelSwitch = null,
             bool buffered = false,
             bool propagateExceptions = false,
-            bool shared = false)
+            bool shared = false,
+            TimeSpan? flushToDiskInterval = null)
         {
             if (addSink == null) throw new ArgumentNullException(nameof(addSink));
             if (formatter == null) throw new ArgumentNullException(nameof(formatter));
@@ -192,12 +197,28 @@ namespace Serilog
 #if ATOMIC_APPEND
                 if (shared)
                 {
-                    sink = new SharedFileSink(path, formatter, fileSizeLimitBytes);
+                    var sfs = new SharedFileSink(path, formatter, fileSizeLimitBytes);
+                    if (flushToDiskInterval.HasValue)
+                    {
+                        sink = new PeriodicFlushToDiskSink<SharedFileSink>(sfs, flushToDiskInterval.Value);
+                    }
+                    else
+                    {
+                        sink = sfs;
+                    }
                 }
                 else
                 {
 #endif
-                    sink = new FileSink(path, formatter, fileSizeLimitBytes, buffered: buffered);
+                    var fs = new FileSink(path, formatter, fileSizeLimitBytes, buffered: buffered);
+                    if (flushToDiskInterval.HasValue)
+                    {
+                        sink = new PeriodicFlushToDiskSink<FileSink>(fs, flushToDiskInterval.Value);
+                    }
+                    else
+                    {
+                        sink = fs;
+                    }
 #if ATOMIC_APPEND
                 }
 #endif
@@ -211,6 +232,7 @@ namespace Serilog
 
                 return addSink(new NullSink(), LevelAlias.Maximum, null);
             }
+
 
             return addSink(sink, restrictedToMinimumLevel, levelSwitch);
         }

--- a/src/Serilog.Sinks.File/FileLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.File/FileLoggerConfigurationExtensions.cs
@@ -197,28 +197,12 @@ namespace Serilog
 #if ATOMIC_APPEND
                 if (shared)
                 {
-                    var sfs = new SharedFileSink(path, formatter, fileSizeLimitBytes);
-                    if (flushToDiskInterval.HasValue)
-                    {
-                        sink = new PeriodicFlushToDiskSink<SharedFileSink>(sfs, flushToDiskInterval.Value);
-                    }
-                    else
-                    {
-                        sink = sfs;
-                    }
+                    sink = new SharedFileSink(path, formatter, fileSizeLimitBytes);
                 }
                 else
                 {
 #endif
-                    var fs = new FileSink(path, formatter, fileSizeLimitBytes, buffered: buffered);
-                    if (flushToDiskInterval.HasValue)
-                    {
-                        sink = new PeriodicFlushToDiskSink<FileSink>(fs, flushToDiskInterval.Value);
-                    }
-                    else
-                    {
-                        sink = fs;
-                    }
+                    sink = new FileSink(path, formatter, fileSizeLimitBytes, buffered: buffered);
 #if ATOMIC_APPEND
                 }
 #endif
@@ -233,6 +217,10 @@ namespace Serilog
                 return addSink(new NullSink(), LevelAlias.Maximum, null);
             }
 
+            if (flushToDiskInterval.HasValue)
+            {
+                sink = new PeriodicFlushToDiskSink(sink, flushToDiskInterval.Value);
+            }
 
             return addSink(sink, restrictedToMinimumLevel, levelSwitch);
         }

--- a/src/Serilog.Sinks.File/Sinks/File/IFlushableFileSink.cs
+++ b/src/Serilog.Sinks.File/Sinks/File/IFlushableFileSink.cs
@@ -1,0 +1,13 @@
+﻿namespace Serilog.Sinks.File
+{
+    /// <summary>
+    /// Supported by (file-based) sinks that can be explicitly flushed.
+    /// </summary>
+    public interface IFlushableFileSink
+    {
+        /// <summary>
+        /// Flush buffered contents to disk.
+        /// </summary>
+        void FlushToDisk();
+    }
+}

--- a/src/Serilog.Sinks.File/Sinks/File/PeriodicFlushToDiskSink.cs
+++ b/src/Serilog.Sinks.File/Sinks/File/PeriodicFlushToDiskSink.cs
@@ -9,27 +9,35 @@ namespace Serilog.Sinks.File
     /// <summary>
     /// A sink wrapper that periodically flushes the wrapped sink to disk.
     /// </summary>
-    /// <typeparam name="TSink">The type of the wrapped sink.</typeparam>
-    public class PeriodicFlushToDiskSink<TSink> : ILogEventSink, IDisposable
-        where TSink : ILogEventSink, IFlushableFileSink
+    public class PeriodicFlushToDiskSink : ILogEventSink, IDisposable
     {
-        readonly TSink _sink;
+        readonly ILogEventSink _sink;
         readonly Timer _timer;
         int _flushRequired;
 
         /// <summary>
-        /// Construct a <see cref="PeriodicFlushToDiskSink{TSink}"/> that wraps
+        /// Construct a <see cref="PeriodicFlushToDiskSink"/> that wraps
         /// <paramref name="sink"/> and flushes it at the specified <paramref name="flushInterval"/>.
         /// </summary>
         /// <param name="sink">The sink to wrap.</param>
         /// <param name="flushInterval">The interval at which to flush the underlying sink.</param>
         /// <exception cref="ArgumentNullException"></exception>
-        public PeriodicFlushToDiskSink(TSink sink, TimeSpan flushInterval)
+        public PeriodicFlushToDiskSink(ILogEventSink sink, TimeSpan flushInterval)
         {
             if (sink == null) throw new ArgumentNullException(nameof(sink));
 
             _sink = sink;
-            _timer = new Timer(_ => FlushToDisk(), null, flushInterval, flushInterval);
+
+            var flushable = sink as IFlushableFileSink;
+            if (flushable != null)
+            {
+                _timer = new Timer(_ => FlushToDisk(flushable), null, flushInterval, flushInterval);
+            }
+            else
+            {
+                _timer = new Timer(_ => { }, null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+                SelfLog.WriteLine("{0} configured to flush {1}, but {2} not implemented", typeof(PeriodicFlushToDiskSink), sink, nameof(IFlushableFileSink));
+            }
         }
 
         /// <inheritdoc />
@@ -46,7 +54,7 @@ namespace Serilog.Sinks.File
             (_sink as IDisposable)?.Dispose();
         }
 
-        void FlushToDisk()
+        void FlushToDisk(IFlushableFileSink flushable)
         {
             try
             {
@@ -54,12 +62,12 @@ namespace Serilog.Sinks.File
                 {
                     // May throw ObjectDisposedException, since we're not trying to synchronize
                     // anything here in the wrapper.
-                    _sink.FlushToDisk();
+                    flushable.FlushToDisk();
                 }
             }
             catch (Exception ex)
             {
-                SelfLog.WriteLine("Could not flush the underlying sink to disk: {0}", ex);
+                SelfLog.WriteLine("{0} could not flush the underlying sink to disk: {1}", typeof(PeriodicFlushToDiskSink), ex);
             }
         }
     }

--- a/src/Serilog.Sinks.File/Sinks/File/PeriodicFlushToDiskSink`1.cs
+++ b/src/Serilog.Sinks.File/Sinks/File/PeriodicFlushToDiskSink`1.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Threading;
+using Serilog.Core;
+using Serilog.Debugging;
+using Serilog.Events;
+
+namespace Serilog.Sinks.File
+{
+    /// <summary>
+    /// A sink wrapper that periodically flushes the wrapped sink to disk.
+    /// </summary>
+    /// <typeparam name="TSink">The type of the wrapped sink.</typeparam>
+    public class PeriodicFlushToDiskSink<TSink> : ILogEventSink, IDisposable
+        where TSink : ILogEventSink, IFlushableFileSink
+    {
+        readonly TSink _sink;
+        readonly Timer _timer;
+        int _flushRequired;
+
+        /// <summary>
+        /// Construct a <see cref="PeriodicFlushToDiskSink{TSink}"/> that wraps
+        /// <paramref name="sink"/> and flushes it at the specified <paramref name="flushInterval"/>.
+        /// </summary>
+        /// <param name="sink">The sink to wrap.</param>
+        /// <param name="flushInterval">The interval at which to flush the underlying sink.</param>
+        /// <exception cref="ArgumentNullException"></exception>
+        public PeriodicFlushToDiskSink(TSink sink, TimeSpan flushInterval)
+        {
+            if (sink == null) throw new ArgumentNullException(nameof(sink));
+
+            _sink = sink;
+            _timer = new Timer(_ => FlushToDisk(), null, flushInterval, flushInterval);
+        }
+
+        /// <inheritdoc />
+        public void Emit(LogEvent logEvent)
+        {
+            _sink.Emit(logEvent);
+            Interlocked.Exchange(ref _flushRequired, 1);
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            _timer.Dispose();
+            (_sink as IDisposable)?.Dispose();
+        }
+
+        void FlushToDisk()
+        {
+            try
+            {
+                if (Interlocked.CompareExchange(ref _flushRequired, 0, 1) == 1)
+                {
+                    // May throw ObjectDisposedException, since we're not trying to synchronize
+                    // anything here in the wrapper.
+                    _sink.FlushToDisk();
+                }
+            }
+            catch (Exception ex)
+            {
+                SelfLog.WriteLine("Could not flush the underlying sink to disk: {0}", ex);
+            }
+        }
+    }
+}

--- a/src/Serilog.Sinks.File/Sinks/File/SharedFileSink.cs
+++ b/src/Serilog.Sinks.File/Sinks/File/SharedFileSink.cs
@@ -27,7 +27,7 @@ namespace Serilog.Sinks.File
     /// <summary>
     /// Write log events to a disk file.
     /// </summary>
-    public sealed class SharedFileSink : ILogEventSink, IDisposable
+    public sealed class SharedFileSink : ILogEventSink, IFlushableFileSink, IDisposable
     {
         readonly MemoryStream _writeBuffer;
         readonly string _path;
@@ -35,7 +35,6 @@ namespace Serilog.Sinks.File
         readonly ITextFormatter _textFormatter;
         readonly long? _fileSizeLimitBytes;
         readonly object _syncRoot = new object();
-        readonly FileInfo _fileInfo;
 
         // The stream is reopened with a larger buffer if atomic writes beyond the current buffer size are needed.
         FileStream _fileOutput;
@@ -53,11 +52,13 @@ namespace Serilog.Sinks.File
         /// <returns>Configuration object allowing method chaining.</returns>
         /// <remarks>The file will be written using the UTF-8 character set.</remarks>
         /// <exception cref="IOException"></exception>
-        public SharedFileSink(string path, ITextFormatter textFormatter, long? fileSizeLimitBytes, Encoding encoding = null)
+        public SharedFileSink(string path, ITextFormatter textFormatter, long? fileSizeLimitBytes,
+            Encoding encoding = null)
         {
             if (path == null) throw new ArgumentNullException(nameof(path));
             if (textFormatter == null) throw new ArgumentNullException(nameof(textFormatter));
-            if (fileSizeLimitBytes.HasValue && fileSizeLimitBytes < 0) throw new ArgumentException("Negative value provided; file size limit must be non-negative");
+            if (fileSizeLimitBytes.HasValue && fileSizeLimitBytes < 0)
+                throw new ArgumentException("Negative value provided; file size limit must be non-negative");
 
             _path = path;
             _textFormatter = textFormatter;
@@ -72,20 +73,16 @@ namespace Serilog.Sinks.File
             // FileSystemRights.AppendData sets the Win32 FILE_APPEND_DATA flag. On Linux this is O_APPEND, but that API is not yet
             // exposed by .NET Core.
             _fileOutput = new FileStream(
-                path, 
+                path,
                 FileMode.Append,
                 FileSystemRights.AppendData,
                 FileShare.ReadWrite,
                 _fileStreamBufferLength,
                 FileOptions.None);
 
-            if (_fileSizeLimitBytes != null)
-            {
-                _fileInfo = new FileInfo(path);
-            }
-
             _writeBuffer = new MemoryStream();
-            _output = new StreamWriter(_writeBuffer, encoding ?? new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            _output = new StreamWriter(_writeBuffer,
+                encoding ?? new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
         }
 
         /// <summary>
@@ -96,12 +93,6 @@ namespace Serilog.Sinks.File
         {
             if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
 
-            if (_fileSizeLimitBytes != null)
-            {
-                if (_fileInfo.Length >= _fileSizeLimitBytes.Value)
-                    return;
-            }
-
             lock (_syncRoot)
             {
                 try
@@ -109,7 +100,7 @@ namespace Serilog.Sinks.File
                     _textFormatter.Format(logEvent, _output);
                     _output.Flush();
                     var bytes = _writeBuffer.GetBuffer();
-                    var length = (int)_writeBuffer.Length;
+                    var length = (int) _writeBuffer.Length;
                     if (length > _fileStreamBufferLength)
                     {
                         var oldOutput = _fileOutput;
@@ -124,6 +115,16 @@ namespace Serilog.Sinks.File
                         _fileStreamBufferLength = length;
 
                         oldOutput.Dispose();
+                    }
+
+                    if (_fileSizeLimitBytes != null)
+                    {
+                        try
+                        {
+                            if (_fileOutput.Length >= _fileSizeLimitBytes.Value)
+                                return;
+                        }
+                        catch (FileNotFoundException) { } // Cheaper and more reliable than checking existence
                     }
 
                     _fileOutput.Write(bytes, 0, length);
@@ -143,11 +144,19 @@ namespace Serilog.Sinks.File
             }
         }
 
-        /// <summary>
-        /// Performs application-defined tasks associated with freeing, releasing, or
-        /// resetting unmanaged resources.
-        /// </summary>
+
+        /// <inheritdoc />
         public void Dispose() => _fileOutput.Dispose();
+
+        /// <inheritdoc />
+        public void FlushToDisk()
+        {
+            lock (_syncRoot)
+            {
+                _output.Flush();
+                _fileOutput.Flush(true);
+            }
+        }
     }
 }
 

--- a/src/Serilog.Sinks.File/Sinks/File/WriteCountingStream.cs
+++ b/src/Serilog.Sinks.File/Sinks/File/WriteCountingStream.cs
@@ -51,6 +51,7 @@ namespace Serilog.Sinks.File
         public override bool CanWrite => true;
         public override long Length => _stream.Length;
 
+
         public override long Position
         {
             get { return _stream.Position; }

--- a/src/Serilog.Sinks.File/project.json
+++ b/src/Serilog.Sinks.File/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "3.0.2-*",
+  "version": "3.1.0-*",
   "description": "Write Serilog events to a text file in plain or JSON format.",
   "authors": [ "Serilog Contributors" ],
   "packOptions": {
@@ -24,7 +24,8 @@
         "System.IO": "4.1.0",
         "System.IO.FileSystem": "4.0.1",
         "System.IO.FileSystem.Primitives": "4.0.1",
-        "System.Text.Encoding.Extensions": "4.0.11"
+        "System.Text.Encoding.Extensions": "4.0.11",
+        "System.Threading.Timer": "4.0.1" 
       }
     }
   }

--- a/src/Serilog.Sinks.File/project.json
+++ b/src/Serilog.Sinks.File/project.json
@@ -9,7 +9,7 @@
     "iconUrl": "http://serilog.net/images/serilog-sink-nuget.png"
   },
   "dependencies": {
-    "Serilog": "2.2.0"
+    "Serilog": "2.3.0"
   },
   "buildOptions": {
     "keyFile": "../../assets/Serilog.snk",

--- a/test/Serilog.Sinks.File.Tests/FileLoggerConfigurationExtensionsTests.cs
+++ b/test/Serilog.Sinks.File.Tests/FileLoggerConfigurationExtensionsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using Serilog;
 using Serilog.Sinks.File.Tests.Support;
 using Serilog.Tests.Support;
@@ -51,5 +52,33 @@ namespace Serilog.Tests
                 Assert.IsType<NotImplementedException>(ex.GetBaseException());
             }
         }
+
+        [Fact]
+        public void WhenFlushingToDiskReportedFileSinkCanBeCreatedAndDisposed()
+        {
+            using (var tmp = TempFolder.ForCaller())
+            using (var log = new LoggerConfiguration()
+                .WriteTo.File(tmp.AllocateFilename(), flushToDiskInterval: TimeSpan.FromMilliseconds(500))
+                .CreateLogger())
+            {
+                log.Information("Hello");
+                Thread.Sleep(TimeSpan.FromSeconds(1));
+            }
+        }
+
+#if ATOMIC_APPEND
+        [Fact]
+        public void WhenFlushingToDiskReportedSharedFileSinkCanBeCreatedAndDisposed()
+        {
+            using (var tmp = TempFolder.ForCaller())
+            using (var log = new LoggerConfiguration()
+                .WriteTo.File(tmp.AllocateFilename(), shared: true, flushToDiskInterval: TimeSpan.FromMilliseconds(500))
+                .CreateLogger())
+            {
+                log.Information("Hello");
+                Thread.Sleep(TimeSpan.FromSeconds(1));
+            }
+        }
+#endif
     }
 }

--- a/test/Serilog.Sinks.File.Tests/Serilog.Sinks.File.Tests.xproj
+++ b/test/Serilog.Sinks.File.Tests/Serilog.Sinks.File.Tests.xproj
@@ -14,5 +14,8 @@
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/test/Serilog.Sinks.File.Tests/SharedFileSinkTests.cs
+++ b/test/Serilog.Sinks.File.Tests/SharedFileSinkTests.cs
@@ -1,11 +1,9 @@
 ﻿#if ATOMIC_APPEND
 
-using System;
 using System.IO;
 using Xunit;
 using Serilog.Formatting.Json;
 using Serilog.Sinks.File.Tests.Support;
-using Serilog.Sinks.File;
 using Serilog.Tests.Support;
 
 namespace Serilog.Sinks.File.Tests

--- a/test/Serilog.Sinks.File.Tests/project.json
+++ b/test/Serilog.Sinks.File.Tests/project.json
@@ -6,7 +6,6 @@
     "dotnet-test-xunit": "1.0.0-rc2-build10025"
   },
   "frameworks": {
-    "net4.5.2": {},
     "netcoreapp1.0": {
       "dependencies": {
         "Microsoft.NETCore.App": {
@@ -18,6 +17,11 @@
         "dnxcore50",
         "portable-net45+win8"
       ]
+    },
+    "net4.5.2": {
+      "buildOptions": {
+        "define": ["ATOMIC_APPEND"]
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes #18 (rolling file support needed downstream).

```csharp
Log.Logger = new LoggerConfiguration()
      .WriteTo.File("log.txt", flushToDiskInterval: TimeSpan.FromSeconds(1))
      .CreateLogger();
```

Attempts to optimize things a bit so no flush is performed unless events have been written.

The `IFlushableFileSink` and `PeriodicFlushToDiskSink<T>` are (reluctantly) public, as this will permit the downstream `RollingFileSink` to wire up to the same mechanism, without us having to encapsulate the periodic flushing behavior in `FileSink` and `SharedFileSink` directly. In the long run, we might get some kind of generialized `IFlushable` into the base Serilog package and make it available across the board through some kind of generic wrapper.

I verified by hand that the `FlushToDisk()` is called, but can't come up with an easy way to test it without some kind of multi-process runner. If we query the file size from Windows from the unit test process, it'll always report a consistent view of the world to us :-).

**Bonus:** discovered the shared file sink tests were inadvertently ignored 😢; after enabling, found a bug preventing size limiting from taking effect. Fixed this too.