### PR TITLE
Add missing synchronization around disposal of owned file streams

### DIFF
--- a/src/Serilog.Sinks.File/Sinks/File/FileSink.cs
+++ b/src/Serilog.Sinks.File/Sinks/File/FileSink.cs
@@ -93,7 +93,13 @@ namespace Serilog.Sinks.File
         }
 
         /// <inheritdoc />
-        public void Dispose() => _output.Dispose();
+        public void Dispose()
+        {
+            lock (_syncRoot)
+            {
+                _output.Dispose();
+            }
+        }
 
         /// <inheritdoc />
         public void FlushToDisk()

--- a/src/Serilog.Sinks.File/Sinks/File/SharedFileSink.cs
+++ b/src/Serilog.Sinks.File/Sinks/File/SharedFileSink.cs
@@ -146,7 +146,13 @@ namespace Serilog.Sinks.File
 
 
         /// <inheritdoc />
-        public void Dispose() => _fileOutput.Dispose();
+        public void Dispose()
+        {
+            lock (_syncRoot)
+            {
+                _fileOutput.Dispose();
+            }
+        }
 
         /// <inheritdoc />
         public void FlushToDisk()


### PR DESCRIPTION
`Dispose()` on the two file sink implementations should always have been synchronized. Now that the sink itself implements asynchronous disk flushing, which may trigger during disposal, the missing locking here is particularly conspicuous.