### PR TITLE
Multiprocess sharing on .NET Core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -234,3 +234,4 @@ _Pvt_Extensions
 
 # FAKE - F# Make
 .fake/
+example/Sample/log.txt

--- a/example/Sample/Program.cs
+++ b/example/Sample/Program.cs
@@ -14,7 +14,7 @@ namespace Sample
             var sw = System.Diagnostics.Stopwatch.StartNew();
 
             Log.Logger = new LoggerConfiguration()
-                .WriteTo.File("log.txt", shared: true)
+                .WriteTo.File("log.txt")
                 .CreateLogger();
 
             for (var i = 0; i < 1000000; ++i)

--- a/example/Sample/Program.cs
+++ b/example/Sample/Program.cs
@@ -11,11 +11,11 @@ namespace Sample
         {
             SelfLog.Enable(Console.Out);
 
-            Log.Logger = new LoggerConfiguration()
-                .WriteTo.File("log.txt")
-                .CreateLogger();
-
             var sw = System.Diagnostics.Stopwatch.StartNew();
+
+            Log.Logger = new LoggerConfiguration()
+                .WriteTo.File("log.txt", shared: true)
+                .CreateLogger();
 
             for (var i = 0; i < 1000000; ++i)
             {

--- a/src/Serilog.Sinks.File/FileLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.File/FileLoggerConfigurationExtensions.cs
@@ -180,32 +180,20 @@ namespace Serilog
             if (formatter == null) throw new ArgumentNullException(nameof(formatter));
             if (path == null) throw new ArgumentNullException(nameof(path));
             if (fileSizeLimitBytes.HasValue && fileSizeLimitBytes < 0) throw new ArgumentException("Negative value provided; file size limit must be non-negative");
-
-            if (shared)
-            {
-#if SHARING
-                if (buffered)
-                    throw new ArgumentException("Buffered writes are not available when file sharing is enabled.", nameof(buffered));
-#else
-                throw new NotSupportedException("File sharing is not supported on this platform.");
-#endif
-            }
+            if (shared && buffered)
+                throw new ArgumentException("Buffered writes are not available when file sharing is enabled.", nameof(buffered));
 
             ILogEventSink sink;
             try
             {
-#if SHARING
                 if (shared)
                 {
                     sink = new SharedFileSink(path, formatter, fileSizeLimitBytes);
                 }
                 else
                 {
-#endif
                     sink = new FileSink(path, formatter, fileSizeLimitBytes, buffered: buffered);
-#if SHARING
                 }
-#endif
             }
             catch (Exception ex)
             {

--- a/src/Serilog.Sinks.File/FileLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.File/FileLoggerConfigurationExtensions.cs
@@ -183,7 +183,7 @@ namespace Serilog
 
             if (shared)
             {
-#if ATOMIC_APPEND
+#if SHARING
                 if (buffered)
                     throw new ArgumentException("Buffered writes are not available when file sharing is enabled.", nameof(buffered));
 #else
@@ -194,7 +194,7 @@ namespace Serilog
             ILogEventSink sink;
             try
             {
-#if ATOMIC_APPEND
+#if SHARING
                 if (shared)
                 {
                     sink = new SharedFileSink(path, formatter, fileSizeLimitBytes);
@@ -203,7 +203,7 @@ namespace Serilog
                 {
 #endif
                     sink = new FileSink(path, formatter, fileSizeLimitBytes, buffered: buffered);
-#if ATOMIC_APPEND
+#if SHARING
                 }
 #endif
             }

--- a/src/Serilog.Sinks.File/Sinks/File/SharedFileSink.AtomicAppend.cs
+++ b/src/Serilog.Sinks.File/Sinks/File/SharedFileSink.AtomicAppend.cs
@@ -52,8 +52,7 @@ namespace Serilog.Sinks.File
         /// <returns>Configuration object allowing method chaining.</returns>
         /// <remarks>The file will be written using the UTF-8 character set.</remarks>
         /// <exception cref="IOException"></exception>
-        public SharedFileSink(string path, ITextFormatter textFormatter, long? fileSizeLimitBytes,
-            Encoding encoding = null)
+        public SharedFileSink(string path, ITextFormatter textFormatter, long? fileSizeLimitBytes, Encoding encoding = null)
         {
             if (path == null) throw new ArgumentNullException(nameof(path));
             if (textFormatter == null) throw new ArgumentNullException(nameof(textFormatter));

--- a/src/Serilog.Sinks.File/Sinks/File/SharedFileSink.OSMutex.cs
+++ b/src/Serilog.Sinks.File/Sinks/File/SharedFileSink.OSMutex.cs
@@ -1,0 +1,132 @@
+﻿// Copyright 2013-2016 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if OS_MUTEX
+
+using System;
+using System.IO;
+using System.Text;
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Formatting;
+using System.Threading;
+
+namespace Serilog.Sinks.File
+{
+    /// <summary>
+    /// Write log events to a disk file.
+    /// </summary>
+    public sealed class SharedFileSink : ILogEventSink, IFlushableFileSink, IDisposable
+    {
+        readonly TextWriter _output;
+        readonly FileStream _underlyingStream;
+        readonly ITextFormatter _textFormatter;
+        readonly long? _fileSizeLimitBytes;
+        readonly object _syncRoot = new object();
+
+        const string MutexNameSuffix = ".serilog";
+        readonly Mutex _mutex;
+
+        /// <summary>Construct a <see cref="FileSink"/>.</summary>
+        /// <param name="path">Path to the file.</param>
+        /// <param name="textFormatter">Formatter used to convert log events to text.</param>
+        /// <param name="fileSizeLimitBytes">The approximate maximum size, in bytes, to which a log file will be allowed to grow.
+        /// For unrestricted growth, pass null. The default is 1 GB. To avoid writing partial events, the last event within the limit
+        /// will be written in full even if it exceeds the limit.</param>
+        /// <param name="encoding">Character encoding used to write the text file. The default is UTF-8 without BOM.</param>
+        /// <returns>Configuration object allowing method chaining.</returns>
+        /// <remarks>The file will be written using the UTF-8 character set.</remarks>
+        /// <exception cref="IOException"></exception>
+        public SharedFileSink(string path, ITextFormatter textFormatter, long? fileSizeLimitBytes, Encoding encoding = null)
+        {
+            if (path == null) throw new ArgumentNullException(nameof(path));
+            if (textFormatter == null) throw new ArgumentNullException(nameof(textFormatter));
+            if (fileSizeLimitBytes.HasValue && fileSizeLimitBytes < 0)
+                throw new ArgumentException("Negative value provided; file size limit must be non-negative");
+
+            _textFormatter = textFormatter;
+            _fileSizeLimitBytes = fileSizeLimitBytes;
+
+            var directory = Path.GetDirectoryName(path);
+            if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            // Backslash is special on Windows
+            _mutex = new Mutex(false, path.Replace('\\', ':') + MutexNameSuffix);
+            _underlyingStream = System.IO.File.Open(path, FileMode.Append, FileAccess.Write, FileShare.ReadWrite);
+            _output = new StreamWriter(_underlyingStream, encoding ?? new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        }
+
+        /// <summary>
+        /// Emit the provided log event to the sink.
+        /// </summary>
+        /// <param name="logEvent">The log event to write.</param>
+        public void Emit(LogEvent logEvent)
+        {
+            if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
+
+            lock (_syncRoot)
+            {
+                _mutex.WaitOne();
+                try
+                {
+                    _underlyingStream.Seek(0, SeekOrigin.End);
+                    if (_fileSizeLimitBytes != null)
+                    {
+                        if (_underlyingStream.Length >= _fileSizeLimitBytes.Value)
+                            return;
+                    }
+
+                    _textFormatter.Format(logEvent, _output);
+                    _output.Flush();
+                    _underlyingStream.Flush();
+                }
+                finally
+                {
+                    _mutex.ReleaseMutex();
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            lock (_syncRoot)
+            {
+                _output.Dispose();
+            }
+        }
+
+        /// <inheritdoc />
+        public void FlushToDisk()
+        {
+            lock (_syncRoot)
+            {
+                _mutex.WaitOne();
+                try
+                {
+                    _underlyingStream.Flush(true);
+                }
+                finally
+                {
+                    _mutex.ReleaseMutex();
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/src/Serilog.Sinks.File/project.json
+++ b/src/Serilog.Sinks.File/project.json
@@ -17,7 +17,18 @@
   },
   "frameworks": {
     "net4.5": {
-      "buildOptions": { "define": [ "ATOMIC_APPEND" ] }
+      "buildOptions": { "define": [ "SHARING", "ATOMIC_APPEND" ] }
+    },
+    "netcoreapp1.0": {
+      "buildOptions": { "define": [ "SHARING", "OS_MUTEX" ] },
+      "dependencies": {
+        "System.IO": "4.1.0",
+        "System.IO.FileSystem": "4.0.1",
+        "System.IO.FileSystem.Primitives": "4.0.1",
+        "System.Text.Encoding.Extensions": "4.0.11",
+        "System.Threading.Timer": "4.0.1",
+        "System.Threading": "4.0.11"
+      }
     },
     "netstandard1.3": {
       "dependencies": {
@@ -25,7 +36,7 @@
         "System.IO.FileSystem": "4.0.1",
         "System.IO.FileSystem.Primitives": "4.0.1",
         "System.Text.Encoding.Extensions": "4.0.11",
-        "System.Threading.Timer": "4.0.1" 
+        "System.Threading.Timer": "4.0.1"
       }
     }
   }

--- a/src/Serilog.Sinks.File/project.json
+++ b/src/Serilog.Sinks.File/project.json
@@ -17,10 +17,10 @@
   },
   "frameworks": {
     "net4.5": {
-      "buildOptions": { "define": [ "SHARING", "ATOMIC_APPEND" ] }
+      "buildOptions": { "define": [ "ATOMIC_APPEND" ] }
     },
-    "netcoreapp1.0": {
-      "buildOptions": { "define": [ "SHARING", "OS_MUTEX" ] },
+    "netstandard1.3": {
+      "buildOptions": { "define": [ "OS_MUTEX" ] },
       "dependencies": {
         "System.IO": "4.1.0",
         "System.IO.FileSystem": "4.0.1",
@@ -28,15 +28,6 @@
         "System.Text.Encoding.Extensions": "4.0.11",
         "System.Threading.Timer": "4.0.1",
         "System.Threading": "4.0.11"
-      }
-    },
-    "netstandard1.3": {
-      "dependencies": {
-        "System.IO": "4.1.0",
-        "System.IO.FileSystem": "4.0.1",
-        "System.IO.FileSystem.Primitives": "4.0.1",
-        "System.Text.Encoding.Extensions": "4.0.11",
-        "System.Threading.Timer": "4.0.1"
       }
     }
   }

--- a/test/Serilog.Sinks.File.Tests/SharedFileSinkTests.cs
+++ b/test/Serilog.Sinks.File.Tests/SharedFileSinkTests.cs
@@ -1,6 +1,4 @@
-﻿#if ATOMIC_APPEND
-
-using System.IO;
+﻿using System.IO;
 using Xunit;
 using Serilog.Formatting.Json;
 using Serilog.Sinks.File.Tests.Support;
@@ -102,5 +100,3 @@ namespace Serilog.Sinks.File.Tests
         }
     }
 }
-
-#endif

--- a/test/Serilog.Sinks.File.Tests/project.json
+++ b/test/Serilog.Sinks.File.Tests/project.json
@@ -19,9 +19,6 @@
       ]
     },
     "net4.5.2": {
-      "buildOptions": {
-        "define": ["ATOMIC_APPEND"]
-      }
     }
   }
 }


### PR DESCRIPTION
~~Adds a new configuration for `netcoreapp1.0`, as although `Mutex` is available on `netstandard1.3` I think it's unlikely to work on all platforms targeted by that TFM (UWP doesn't like _System.Threading_ references, for instance).~~

Performance is about 10x slower than atomic append, but otherwise appears to work as far as my limited tests have covered.

Required for serilog/serilog-sinks-rollingfile#37.