### PR TITLE
Check for directory existence before attempting access.

### DIFF
--- a/src/Serilog.Sinks.File/Sinks/File/RollingFileSink.cs
+++ b/src/Serilog.Sinks.File/Sinks/File/RollingFileSink.cs
@@ -117,8 +117,11 @@ namespace Serilog.Sinks.File
             var existingFiles = Enumerable.Empty<string>();
             try
             {
-                existingFiles = Directory.GetFiles(_roller.LogFileDirectory, _roller.DirectorySearchPattern)
+                if (Directory.Exists(_roller.LogFileDirectory))
+                {
+                    existingFiles = Directory.GetFiles(_roller.LogFileDirectory, _roller.DirectorySearchPattern)
                                          .Select(Path.GetFileName);
+                }
             }
             catch (DirectoryNotFoundException) { }
 


### PR DESCRIPTION
Stops exception from being thrown and tripping breakpoints when debugging application code.

Plus good practice to avoid exceptions.