### PR TITLE
Added a test for rolling a file when its sequence reached int.MaxValue.

### DIFF
--- a/test/Serilog.Sinks.File.Tests/RollingFileSinkTests.cs
+++ b/test/Serilog.Sinks.File.Tests/RollingFileSinkTests.cs
@@ -336,7 +336,7 @@ namespace Serilog.Sinks.File.Tests
                         retainedFileCountLimit: 1)
                     .CreateLogger())
                 {
-                    var infoEvent = Some.InformationEvent();
+                    /*var infoEvent = Some.InformationEvent();
                     // The following log.Write() will run the logger into an infinite loop.
                     // The loop begins in RollingFileSink.cs+85; there is a while condition that will be always true.
                     log.Write(infoEvent);
@@ -345,7 +345,8 @@ namespace Serilog.Sinks.File.Tests
 
                     Assert.Equal(1, files.Length);
                     // Not sure if the name should be with or without a suffix
-                    Assert.True(files[0].EndsWith(fileName), files[0]);
+                    Assert.True(files[0].EndsWith(fileName), files[0]);*/
+                    throw new NotImplementedException();
                 }
             }
         }


### PR DESCRIPTION
A test for an issue https://github.com/serilog/serilog-sinks-file/issues/131.

I specify a file name for a logger to write to, then manually create a file that has the name of the original file with an appended suffix of int.MaxValue. Later, log.Write() will fall into an infinite loop. I didn't figure out how to properly check for it. Also I'm not sure if the rolled file name should be with or without the suffix.