### PR TITLE
Ability to delete log files and recreate them immediately

### DIFF
--- a/src/Serilog.Sinks.File/Sinks/File/SharedFileSink.AtomicAppend.cs
+++ b/src/Serilog.Sinks.File/Sinks/File/SharedFileSink.AtomicAppend.cs
@@ -72,7 +72,7 @@ namespace Serilog.Sinks.File
                 path,
                 FileMode.Append,
                 FileSystemRights.AppendData,
-                FileShare.ReadWrite,
+                FileShare.ReadWrite | FileShare.Delete,
                 _fileStreamBufferLength,
                 FileOptions.None);
 
@@ -101,7 +101,23 @@ namespace Serilog.Sinks.File
                             _path,
                             FileMode.Append,
                             FileSystemRights.AppendData,
-                            FileShare.ReadWrite,
+                            FileShare.ReadWrite | FileShare.Delete,
+                            length,
+                            FileOptions.None);
+                        _fileStreamBufferLength = length;
+
+                        oldOutput.Dispose();
+                    }
+
+                    if (!System.IO.File.Exists(_path))
+                    {
+                        var oldOutput = _fileOutput;
+
+                        _fileOutput = new FileStream(
+                            _path,
+                            FileMode.Append,
+                            FileSystemRights.AppendData,
+                            FileShare.ReadWrite | FileShare.Delete,
                             length,
                             FileOptions.None);
                         _fileStreamBufferLength = length;

--- a/test/Serilog.Sinks.File.Tests/SharedFileSinkTests.cs
+++ b/test/Serilog.Sinks.File.Tests/SharedFileSinkTests.cs
@@ -26,6 +26,38 @@ namespace Serilog.Sinks.File.Tests
                 Assert.Contains("Hello, world!", lines[0]);
             }
         }
+        [Fact]
+        public void FileIsReWrittenAfterEventIfDeleted()
+        {
+            using (var tmp = TempFolder.ForCaller())
+            {
+                var nonexistent = tmp.AllocateFilename("txt");
+                var evt = Some.LogEvent("Hello, world!");
+
+                void Emmit()
+                {
+                    using (var sink = new SharedFileSink(nonexistent, new JsonFormatter(), null))
+                    {
+                        sink.Emit(evt);
+                    }
+                }
+
+                Emmit();
+                var lines = System.IO.File.ReadAllLines(nonexistent);
+                Assert.Contains("Hello, world!", lines[0]);
+                Assert.Single(lines);
+
+                System.IO.File.Delete(nonexistent);
+                Assert.False(System.IO.File.Exists(nonexistent));
+                Assert.Throws<FileNotFoundException>(() => System.IO.File.ReadAllLines(nonexistent));
+
+                Emmit();
+                lines = System.IO.File.ReadAllLines(nonexistent);
+                Assert.True(System.IO.File.Exists(nonexistent));
+                Assert.Contains("Hello, world!", lines[0]);
+                Assert.Single(lines);
+            }
+        }
 
         [Fact]
         public void FileIsAppendedToWhenAlreadyCreated()


### PR DESCRIPTION
As discussed in #96 and #128, this gives the ability to delete files when is created by a SharedFileSink and recreates the rolling file when deleted.
Please, note that this is still a initial version for the solution, I'm going to implement more tests and eliminate some duplication. 

I'd like to start this discussion in order gather some insights from the project maintainers and address some questions I have. I'm gonna give some more thoughts on this one as soon as I can.

## Allow Log File to be Deleted at Runtime #96 
I was able to make this work by just adding `FileShare.Delete` at both  `FileStream` instances. This would make all shared files 'deleteable'.

About that: 
- Is ok to make all shared files 'deleteable'?; or
- Should I make another configuration and only enable deletion capability when is configured by the user? (eg.: `canDeleteFiles: true`) 

## Recreate current rolling file immediately to log on file deleting  #128  
This was a little more tricky, but I was able to make this work using `SharedFileSink.OSMutex`

Questions I have:
- How do I reproduce/run `SharedFileSink.AtomicAppend`? I wasn't able to run this class in my tests or by debugging.
- Should we be worried about the performance of `File.Exists()` at `SharedFileSink.OSMutex.cs` line 85? Do you guys have a better idea to make this check? This was actually how I managed to make the file be re-created right after deletion.