### PR TITLE
Allow FileLifecycleHooks to change the length of the stream

### DIFF
--- a/src/Serilog.Sinks.File/Sinks/File/FileSink.cs
+++ b/src/Serilog.Sinks.File/Sinks/File/FileSink.cs
@@ -80,7 +80,9 @@ namespace Serilog.Sinks.File
                 Directory.CreateDirectory(directory);
             }
 
-            Stream outputStream = _underlyingStream = System.IO.File.Open(path, FileMode.Append, FileAccess.Write, FileShare.Read);
+            Stream outputStream = _underlyingStream = System.IO.File.Open(path, FileMode.OpenOrCreate, FileAccess.Write, FileShare.Read);
+            outputStream.Seek(0, SeekOrigin.End);
+
             if (_fileSizeLimitBytes != null)
             {
                 outputStream = _countingStreamWrapper = new WriteCountingStream(_underlyingStream);

--- a/src/Serilog.Sinks.File/Sinks/File/WriteCountingStream.cs
+++ b/src/Serilog.Sinks.File/Sinks/File/WriteCountingStream.cs
@@ -63,7 +63,13 @@ namespace Serilog.Sinks.File
 
         public override void SetLength(long value)
         {
-            throw new NotSupportedException();
+            _stream.SetLength(value);
+
+            if (value < CountedLength)
+            {
+                // File is now shorter and our position has changed to _stream.Length
+                CountedLength = _stream.Length;
+            }
         }
 
         public override int Read(byte[] buffer, int offset, int count)

--- a/test/Serilog.Sinks.File.Tests/Support/TruncateFileHook.cs
+++ b/test/Serilog.Sinks.File.Tests/Support/TruncateFileHook.cs
@@ -1,0 +1,18 @@
+using System.IO;
+using System.Text;
+
+namespace Serilog.Sinks.File.Tests.Support
+{
+    /// <inheritdoc />
+    /// <summary>
+    /// Demonstrates the use of <seealso cref="T:Serilog.FileLifecycleHooks" />, by emptying the file before it's written to
+    /// </summary>
+    public class TruncateFileHook : FileLifecycleHooks
+    {
+        public override Stream OnFileOpened(Stream underlyingStream, Encoding encoding)
+        {
+            underlyingStream.SetLength(0);
+            return base.OnFileOpened(underlyingStream, encoding);
+        }
+    }
+}

--- a/test/Serilog.Sinks.File.Tests/WriteCountingStreamTests.cs
+++ b/test/Serilog.Sinks.File.Tests/WriteCountingStreamTests.cs
@@ -1,0 +1,83 @@
+﻿using System.IO;
+using System.Text;
+using Serilog.Sinks.File.Tests.Support;
+using Xunit;
+
+namespace Serilog.Sinks.File.Tests
+{
+    public class WriteCountingStreamTests
+    {
+        [Fact]
+        public void CountedLengthIsResetToStreamLengthIfNewSizeIsSmaller()
+        {
+            // If we counted 10 bytes written and SetLength was called with a smaller length (e.g. 5)
+            // we adjust the counter to the new byte count of the file to reflect reality
+
+            using (var tmp = TempFolder.ForCaller())
+            {
+                var path = tmp.AllocateFilename("txt");
+
+                long streamLengthAfterSetLength;
+                long countedLengthAfterSetLength;
+
+                using (var fileStream = System.IO.File.Open(path, FileMode.Create, FileAccess.Write, FileShare.Read))
+                using (var countingStream = new WriteCountingStream(fileStream))
+                using (var writer = new StreamWriter(countingStream, new UTF8Encoding(false)))
+                {
+                    writer.WriteLine("Hello, world!");
+                    writer.Flush();
+
+                    countingStream.SetLength(5);
+                    streamLengthAfterSetLength = countingStream.Length;
+                    countedLengthAfterSetLength = countingStream.CountedLength;
+                }
+
+                Assert.Equal(5, streamLengthAfterSetLength);
+                Assert.Equal(5, countedLengthAfterSetLength);
+
+                var lines = System.IO.File.ReadAllLines(path);
+
+                Assert.Single(lines);
+                Assert.Equal("Hello", lines[0]);
+            }
+        }
+
+        [Fact]
+        public void CountedLengthRemainsTheSameIfNewSizeIsLarger()
+        {
+            // If we counted 10 bytes written and SetLength was called with a larger length (e.g. 100)
+            // we leave the counter intact because our position on the stream remains the same... The
+            // file just grew larger in size
+
+            using (var tmp = TempFolder.ForCaller())
+            {
+                var path = tmp.AllocateFilename("txt");
+
+                long streamLengthBeforeSetLength;
+                long streamLengthAfterSetLength;
+                long countedLengthAfterSetLength;
+
+                using (var fileStream = System.IO.File.Open(path, FileMode.Create, FileAccess.Write, FileShare.Read))
+                using (var countingStream = new WriteCountingStream(fileStream))
+                using (var writer = new StreamWriter(countingStream, new UTF8Encoding(false)))
+                {
+                    writer.WriteLine("Hello, world!");
+                    writer.Flush();
+
+                    streamLengthBeforeSetLength = countingStream.CountedLength;
+                    countingStream.SetLength(100);
+                    streamLengthAfterSetLength = countingStream.Length;
+                    countedLengthAfterSetLength = countingStream.CountedLength;
+                }
+
+                Assert.Equal(100, streamLengthAfterSetLength);
+                Assert.Equal(streamLengthBeforeSetLength, countedLengthAfterSetLength);
+
+                var lines = System.IO.File.ReadAllLines(path);
+
+                Assert.Equal(2, lines.Length);
+                Assert.Equal("Hello, world!", lines[0]);
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Open files with `FileMode.OpenOrCreate` and immediately position the cursor at the end of the file, effectively doing what the `File` class does behind the scenes when using `FileMode.Append`

- Implement `SetLength` in `WriteCountingStream` adjusting `CountedLength` if necessary (i.e. when the new size of the stream is shorter)

---

Resolves… #186
