### PR TITLE
Add ability to capture path of log file opened, via FileLifecycleHooks

### DIFF
--- a/src/Serilog.Sinks.File/Sinks/File/FileLifeCycleHookChain.cs
+++ b/src/Serilog.Sinks.File/Sinks/File/FileLifeCycleHookChain.cs
@@ -29,10 +29,10 @@ namespace Serilog.Sinks.File
             _second = second ?? throw new ArgumentNullException(nameof(second));
         }
 
-        public override Stream OnFileOpened(Stream underlyingStream, Encoding encoding)
+        public override Stream OnFileOpened(string path, Stream underlyingStream, Encoding encoding)
         {
-            var firstStreamResult = _first.OnFileOpened(underlyingStream, encoding);
-            var secondStreamResult = _second.OnFileOpened(firstStreamResult, encoding);
+            var firstStreamResult = _first.OnFileOpened(path, underlyingStream, encoding);
+            var secondStreamResult = _second.OnFileOpened(path, firstStreamResult, encoding);
 
             return secondStreamResult;
         }

--- a/src/Serilog.Sinks.File/Sinks/File/FileLifecycleHooks.cs
+++ b/src/Serilog.Sinks.File/Sinks/File/FileLifecycleHooks.cs
@@ -32,6 +32,21 @@ namespace Serilog.Sinks.File
         /// A value must be returned from overrides of this method. Serilog will flush and/or dispose the returned value, but will not
         /// dispose the stream initially passed in unless it is itself returned.
         /// </remarks>
+        /// <param name="path">The full path to the log file.</param>
+        /// <param name="underlyingStream">The underlying <see cref="Stream"/> opened on the log file.</param>
+        /// <param name="encoding">The encoding to use when reading/writing to the stream.</param>
+        /// <returns>The <see cref="Stream"/> Serilog should use when writing events to the log file.</returns>
+        public virtual Stream OnFileOpened(string path, Stream underlyingStream, Encoding encoding) => OnFileOpened(underlyingStream, encoding);
+
+        /// <summary>
+        /// Initialize or wrap the <paramref name="underlyingStream"/> opened on the log file. This can be used to write
+        /// file headers, or wrap the stream in another that adds buffering, compression, encryption, etc. The underlying
+        /// file may or may not be empty when this method is called.
+        /// </summary>
+        /// <remarks>
+        /// A value must be returned from overrides of this method. Serilog will flush and/or dispose the returned value, but will not
+        /// dispose the stream initially passed in unless it is itself returned.
+        /// </remarks>
         /// <param name="underlyingStream">The underlying <see cref="Stream"/> opened on the log file.</param>
         /// <param name="encoding">The encoding to use when reading/writing to the stream.</param>
         /// <returns>The <see cref="Stream"/> Serilog should use when writing events to the log file.</returns>

--- a/src/Serilog.Sinks.File/Sinks/File/FileSink.cs
+++ b/src/Serilog.Sinks.File/Sinks/File/FileSink.cs
@@ -91,7 +91,7 @@ namespace Serilog.Sinks.File
 
             if (hooks != null)
             {
-                outputStream = hooks.OnFileOpened(outputStream, encoding) ??
+                outputStream = hooks.OnFileOpened(path, outputStream, encoding) ??
                                throw new InvalidOperationException($"The file lifecycle hook `{nameof(FileLifecycleHooks.OnFileOpened)}(...)` returned `null`.");
             }
 

--- a/test/Serilog.Sinks.File.Tests/FileSinkTests.cs
+++ b/test/Serilog.Sinks.File.Tests/FileSinkTests.cs
@@ -206,6 +206,23 @@ namespace Serilog.Sinks.File.Tests
             }
         }
 
+        [Fact]
+        public static void OnOpenedLifecycleHookCanCaptureFilePath()
+        {
+            using (var tmp = TempFolder.ForCaller())
+            {
+                var capturePath = new CaptureFilePathHook();
+
+                var path = tmp.AllocateFilename("txt");
+                using (new FileSink(path, new JsonFormatter(), null, new UTF8Encoding(false), false, capturePath))
+                {
+                    // Open and capture the log file path
+                }
+
+                Assert.Equal(path, capturePath.Path);
+            }
+        }
+
         static void WriteTwoEventsAndCheckOutputFileLength(long? maxBytes, Encoding encoding)
         {
             using (var tmp = TempFolder.ForCaller())

--- a/test/Serilog.Sinks.File.Tests/Support/CaptureFilePathHook.cs
+++ b/test/Serilog.Sinks.File.Tests/Support/CaptureFilePathHook.cs
@@ -1,0 +1,20 @@
+﻿using System.IO;
+using System.Text;
+
+namespace Serilog.Sinks.File.Tests.Support
+{
+    /// <inheritdoc />
+    /// <summary>
+    /// Demonstrates the use of <seealso cref="T:Serilog.FileLifecycleHooks" />, by capturing the log file path
+    /// </summary>
+    class CaptureFilePathHook : FileLifecycleHooks
+    {
+        public string Path { get; private set; }
+
+        public override Stream OnFileOpened(string path, Stream _, Encoding __)
+        {
+            Path = path;
+            return base.OnFileOpened(path, _, __);
+        }
+    }
+}


### PR DESCRIPTION
Adds an overload to `FileLifecycleHooks` that includes the path to the log file that has been opened.

```csharp
public virtual Stream OnFileOpened(string path, Stream underlyingStream, Encoding encoding) { ... }
```

By default, it calls the current `OnFileOpened(Stream, Encoding)` to maintain compatibility with existing hooks.

We can consider marking the current `OnFileOpened(Stream, Encoding)` as `Obsolete` on this or on a future pull-request depending on the next milestone/release.

---

Resolves #191
