### PR TITLE
Not crash when path is temporarily not available

### DIFF
--- a/src/Serilog.Sinks.File/Sinks/File/WriteCountingStream.cs
+++ b/src/Serilog.Sinks.File/Sinks/File/WriteCountingStream.cs
@@ -43,12 +43,23 @@ namespace Serilog.Sinks.File
             CountedLength += count;
         }
 
-        public override void Flush() => _stream.Flush();
+        public override void Flush() => HandleFlush();
         public override bool CanRead => false;
         public override bool CanSeek => _stream.CanSeek;
         public override bool CanWrite => true;
         public override long Length => _stream.Length;
 
+
+        private void HandleFlush()
+        {
+            try
+            {
+                _stream.Flush();
+            }
+            catch
+            {
+            }
+        }
 
         public override long Position
         {


### PR DESCRIPTION
A simple change to handle if a path becomes un-available such as network or via usb. This was still passing unit tests and did not show a major perfomance loss:

with changes:
Elapsed: 6401 ms
Size: 58000000

original code:
Elapsed: 6199 ms
Size: 58000000