### PR TITLE
Update Project URL so it links to repo

### DIFF
--- a/src/Serilog.Sinks.File/Serilog.Sinks.File.csproj
+++ b/src/Serilog.Sinks.File/Serilog.Sinks.File.csproj
@@ -14,7 +14,7 @@
     <PackageTags>serilog;file</PackageTags>
     <PackageIcon>images\icon.png</PackageIcon>
     <PackageIconUrl>https://serilog.net/images/serilog-sink-nuget.png</PackageIconUrl>
-    <PackageProjectUrl>https://serilog.net</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/serilog/serilog-sinks-file</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/serilog/serilog-sinks-file</RepositoryUrl>
     <RepositoryType>git</RepositoryType>


### PR DESCRIPTION
I updated the Project URL so you can easily access the project from NuGet.
The same way as other Serilog packages, for example Serilog.Extensions.Logging:
![afbeelding](https://user-images.githubusercontent.com/19996084/134031122-9eb176f6-eca0-4ffa-8815-716fd967e93b.png)