### PR TITLE
Add net6.0 target; update test TFMs

### DIFF
--- a/example/Sample/Sample.csproj
+++ b/example/Sample/Sample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48;net5.0</TargetFrameworks>
+    <TargetFrameworks>net48;net6.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <AssemblyName>Sample</AssemblyName>

--- a/src/Serilog.Sinks.File/Serilog.Sinks.File.csproj
+++ b/src/Serilog.Sinks.File/Serilog.Sinks.File.csproj
@@ -4,7 +4,7 @@
     <Description>Write Serilog events to text files in plain or JSON format.</Description>
     <VersionPrefix>5.0.1</VersionPrefix>
     <Authors>Serilog Contributors</Authors>
-    <TargetFrameworks>net45;netstandard1.3;netstandard2.0;netstandard2.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.3;netstandard2.0;netstandard2.1;net5.0;net6.0;net7.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Serilog.Sinks.File/Serilog.Sinks.File.csproj
+++ b/src/Serilog.Sinks.File/Serilog.Sinks.File.csproj
@@ -4,7 +4,7 @@
     <Description>Write Serilog events to text files in plain or JSON format.</Description>
     <VersionPrefix>5.0.1</VersionPrefix>
     <Authors>Serilog Contributors</Authors>
-    <TargetFrameworks>net45;netstandard1.3;netstandard2.0;netstandard2.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.3;netstandard2.0;netstandard2.1;net5.0;net6.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Serilog.Sinks.File/Serilog.Sinks.File.csproj
+++ b/src/Serilog.Sinks.File/Serilog.Sinks.File.csproj
@@ -4,7 +4,7 @@
     <Description>Write Serilog events to text files in plain or JSON format.</Description>
     <VersionPrefix>5.0.1</VersionPrefix>
     <Authors>Serilog Contributors</Authors>
-    <TargetFrameworks>net45;netstandard1.3;netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.3;netstandard2.0;netstandard2.1;net6.0;net7.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/test/Serilog.Sinks.File.Tests/Serilog.Sinks.File.Tests.csproj
+++ b/test/Serilog.Sinks.File.Tests/Serilog.Sinks.File.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 
-    <TargetFrameworks>net48;net5.0</TargetFrameworks>
+    <TargetFrameworks>net48;net6.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>


### PR DESCRIPTION
It's time to support .net 6, and .net 7. .net5.0 is EOL over a year ago.