### PR TITLE
Added pattern {date} and {seq} to file path in rolling sink.

### DIFF
--- a/src/Serilog.Sinks.File/Sinks/File/PathTokenizer.cs
+++ b/src/Serilog.Sinks.File/Sinks/File/PathTokenizer.cs
@@ -1,0 +1,161 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Serilog.Sinks.File
+{
+    internal class PathTokenizer
+    {
+        public class Token
+        {
+            public enum TokenType { Text, DirectorySeparator, Parameter, Extension }
+
+            public TokenType Type { get; set; }
+
+            public string Value { get; set; } = string.Empty;
+
+            public string? Argument { get; set; }
+
+            public override string ToString()
+            {
+                switch (Type)
+                {
+                    default:
+                    case TokenType.Text:
+                        return Value.Replace("{", "{{").Replace("}", "}}");
+                    case TokenType.DirectorySeparator:
+                        return Path.DirectorySeparatorChar.ToString();
+                    case TokenType.Parameter:
+                        if (string.IsNullOrEmpty(Argument))
+                            return string.Format("{{{0}}}", Value.Replace("{", "{{").Replace("}", "}}"));
+                        else
+                            return string.Format("{{{0}:{1}}}", Value.Replace("{", "{{").Replace("}", "}}"), Argument?.Replace("{", "{{").Replace("}", "}}"));
+                    case TokenType.Extension:
+                        return "." + Value.Replace("{", "{{").Replace("}", "}}");
+                }
+            }
+        }
+
+        public static List<Token> Tokenize(string str)
+        {
+            var res = new List<Token>();
+            var type = Token.TokenType.Text;
+            var current = new StringBuilder();
+            var inception = 0;
+
+            foreach (var c in str)
+            {
+                if (c == '{')
+                {
+                    if (type != Token.TokenType.Parameter)
+                    {
+                        if (current.Length > 0)
+                        {
+                            res.Add(new Token
+                            {
+                                Type = type,
+                                Value = current.ToString(),
+                            });
+                            current.Length = 0;
+                        }
+
+                        type = Token.TokenType.Parameter;
+                        continue;
+                    }
+                    else
+                        inception++;
+                }
+                else if (c == '}' && type == Token.TokenType.Parameter)
+                {
+                    if (inception > 0)
+                        inception--;
+                    else
+                    {
+                        if (current.Length > 0)
+                        {
+                            string? a = null;
+                            var v = current.ToString();
+                            var i = v.IndexOf(':');
+                            if (i > 0)
+                            {
+                                a = v.Substring(i + 1);
+                                v = v.Substring(0, i);
+                            }
+                            res.Add(new Token
+                            {
+                                Type = type,
+                                Value = v,
+                                Argument = a,
+                            });
+                            current.Length = 0;
+                        }
+
+                        type = Token.TokenType.Text;
+
+                        continue;
+                    }
+                }
+                else if (c == Path.DirectorySeparatorChar && type == Token.TokenType.Text)
+                {
+                    if (current.Length > 0)
+                    {
+                        res.Add(new Token
+                        {
+                            Type = type,
+                            Value = current.ToString(),
+                        });
+
+                        current.Length = 0;
+                    }
+
+                    res.Add(new Token
+                    {
+                        Type = Token.TokenType.DirectorySeparator,
+                    });
+
+                    type = Token.TokenType.Text;
+
+                    continue;
+                }
+
+                current.Append(c);
+            }
+
+            if (current.Length > 0)
+            {
+                res.Add(new Token
+                {
+                    Type = type,
+                    Value = current.ToString(),
+                });
+
+                current.Length = 0;
+            }
+
+            var l = res.Last();
+            if (l != null && l.Type == Token.TokenType.Text)
+            {
+                var i = l.Value.LastIndexOf(".");
+                if (i >= 0)
+                {
+                    var e = l.Value.Substring(i + 1);
+                    if (i > 0)
+                        l.Value = l.Value.Substring(0, i);
+                    else
+                        res.Remove(l);
+
+                    res.Add(new Token
+                    {
+                        Type = Token.TokenType.Extension,
+                        Value = e,
+                    });
+                }
+            }
+
+            return res;
+        }
+    }
+}

--- a/src/Serilog.Sinks.File/Sinks/File/RollingFileSink.cs
+++ b/src/Serilog.Sinks.File/Sinks/File/RollingFileSink.cs
@@ -124,8 +124,7 @@ namespace Serilog.Sinks.File
             {
                 if (Directory.Exists(_roller.LogFileDirectory))
                 {
-                    existingFiles = Directory.GetFiles(_roller.LogFileDirectory, _roller.DirectorySearchPattern)
-                                        .Select(f => Path.GetFileName(f));
+                    existingFiles = Directory.GetFiles(_roller.LogFileDirectory, _roller.DirectorySearchPattern, SearchOption.AllDirectories);
                 }
             }
             catch (DirectoryNotFoundException) { }
@@ -183,8 +182,7 @@ namespace Serilog.Sinks.File
 
             // We consider the current file to exist, even if nothing's been written yet,
             // because files are only opened on response to an event being processed.
-            var potentialMatches = Directory.GetFiles(_roller.LogFileDirectory, _roller.DirectorySearchPattern)
-                .Select(f => Path.GetFileName(f))
+            var potentialMatches = Directory.GetFiles(_roller.LogFileDirectory, _roller.DirectorySearchPattern, SearchOption.AllDirectories)
                 .Union(new[] { currentFileName });
 
             var newestFirst = _roller
@@ -215,7 +213,7 @@ namespace Serilog.Sinks.File
 
         bool ShouldRetainFile(RollingLogFile file, int index, DateTime now)
         {
-            if (_retainedFileCountLimit.HasValue && index >= _retainedFileCountLimit.Value - 1)
+            if (_retainedFileCountLimit.HasValue && index >= _retainedFileCountLimit.Value)
                 return false;
 
             if (_retainedFileTimeLimit.HasValue && file.DateTime.HasValue &&


### PR DESCRIPTION
You now can use `{date}` and `{seq}` to define where date and sequence number will be stored. You can also alter date format by using `{date:yyyy-MM-dd}` for example.