### PR TITLE
Generate and publish symbols package

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,14 +18,15 @@ artifacts:
 - path: artifacts/Serilog.*.snupkg
 deploy:
 - provider: NuGet
+  server: https://nuget.pkg.github.com/monticola/index.json
   api_key:
-    secure: LE+O+3Zs0nz2F/+M4eDvKBhEBUpUV0t864vN/2dxwa7aIVqeU3pKSMjWRX+JWJ49
+    secure: 87VXONffNiU8ErfeaSaETZLTOfF7GKHqv/CD0tNpYc52+kZlBP2GgsQhpOjv8Reo
   on:
-    branch: /^(main|dev)$/
+    branch: /^(main|dev|serilog-sinks-file)$/
 - provider: GitHub
   auth_token:
-    secure: p4LpVhBKxGS5WqucHxFQ5c7C8cP74kbNB0Z8k9Oxx/PMaDQ1+ibmoexNqVU5ZlmX
+    secure: 87VXONffNiU8ErfeaSaETZLTOfF7GKHqv/CD0tNpYc52+kZlBP2GgsQhpOjv8Reo
   artifact: /Serilog.*(\.|\.s)nupkg/
   tag: v$(appveyor_build_version)
   on:
-    branch: main
+    branch: (main|serilog-sinks-file)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,17 +15,17 @@ for:
 test: off
 artifacts:
 - path: artifacts/Serilog.*.nupkg
+- path: artifacts/Serilog.*.snupkg
 deploy:
 - provider: NuGet
   api_key:
     secure: LE+O+3Zs0nz2F/+M4eDvKBhEBUpUV0t864vN/2dxwa7aIVqeU3pKSMjWRX+JWJ49
-  skip_symbols: true
   on:
     branch: /^(main|dev)$/
 - provider: GitHub
   auth_token:
     secure: p4LpVhBKxGS5WqucHxFQ5c7C8cP74kbNB0Z8k9Oxx/PMaDQ1+ibmoexNqVU5ZlmX
-  artifact: /Serilog.*\.nupkg/
+  artifact: /Serilog.*(\.|\.s)nupkg/
   tag: v$(appveyor_build_version)
   on:
     branch: main

--- a/src/Serilog.Sinks.File/Serilog.Sinks.File.csproj
+++ b/src/Serilog.Sinks.File/Serilog.Sinks.File.csproj
@@ -24,6 +24,8 @@
     <EnableSourceLink Condition="'$(EnableSourceLink)' == ''">false</EnableSourceLink>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <IncludeSymbols>True</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This changes modify Serilog.Sinks.File in order to generate symbols package (snupkg). Appveyor configuration is modified in order to collect the new artifact, and also to publish it both to nuget and to github release.

Fixes #194  