### PR TITLE
Fix issue with force-reopen after 30 minutes

### DIFF
--- a/src/Serilog.Sinks.File/Sinks/File/FileSink.cs
+++ b/src/Serilog.Sinks.File/Sinks/File/FileSink.cs
@@ -91,8 +91,16 @@ public sealed class FileSink : IFileSink, IDisposable
 
         if (hooks != null)
         {
-            outputStream = hooks.OnFileOpened(path, outputStream, encoding) ??
-                           throw new InvalidOperationException($"The file lifecycle hook `{nameof(FileLifecycleHooks.OnFileOpened)}(...)` returned `null`.");
+            try
+            {
+                outputStream = hooks.OnFileOpened(path, outputStream, encoding) ??
+                               throw new InvalidOperationException($"The file lifecycle hook `{nameof(FileLifecycleHooks.OnFileOpened)}(...)` returned `null`.");
+            }
+            catch
+            {
+                outputStream?.Dispose();
+                throw;
+            }
         }
 
         _output = new StreamWriter(outputStream, encoding);

--- a/src/Serilog.Sinks.File/Sinks/File/RollingFileSink.cs
+++ b/src/Serilog.Sinks.File/Sinks/File/RollingFileSink.cs
@@ -84,10 +84,12 @@ sealed class RollingFileSink : ILogEventSink, IFlushableFileSink, IDisposable
                 AlignCurrentFileTo(now, nextSequence: true);
             }
 
+            /* TODO: We REALLY should add this to avoid stuff become missing undetected.
             if (_currentFile == null)
             {
                 SelfLog.WriteLine("Log event {0} was lost since it was not possible to open the file or create a new one.", logEvent.RenderMessage());
             }
+            */
         }
     }
 

--- a/test/Serilog.Sinks.File.Tests/RollingFileSinkTests.cs
+++ b/test/Serilog.Sinks.File.Tests/RollingFileSinkTests.cs
@@ -4,11 +4,19 @@ using Serilog.Events;
 using Serilog.Sinks.File.Tests.Support;
 using Serilog.Configuration;
 using Serilog.Core;
+using Xunit.Abstractions;
 
 namespace Serilog.Sinks.File.Tests;
 
 public class RollingFileSinkTests
 {
+    private readonly ITestOutputHelper _testOutputHelper;
+
+    public RollingFileSinkTests(ITestOutputHelper testOutputHelper)
+    {
+        _testOutputHelper = testOutputHelper;
+    }
+
     [Fact]
     public void LogEventsAreEmittedToTheFileNamedAccordingToTheEventTimestamp()
     {
@@ -146,6 +154,130 @@ public class RollingFileSinkTests
     }
 
     [Fact]
+    public void WhenFirstOpeningFailedWithLockRetryDelayedUntilNextCheckpoint()
+    {
+        var fileName = Some.String() + ".txt";
+        using var temp = new TempFolder();
+        using var log = new LoggerConfiguration()
+            .WriteTo.File(Path.Combine(temp.Path, fileName), rollOnFileSizeLimit: true, fileSizeLimitBytes: 1, rollingInterval: RollingInterval.Minute, hooks: new FailOpeningHook(true, 2, 3, 4))
+            .CreateLogger();
+        LogEvent e1 = Some.InformationEvent(new DateTime(2012, 10, 28)),
+            e2 = Some.InformationEvent(e1.Timestamp.AddSeconds(1)),
+            e3 = Some.InformationEvent(e1.Timestamp.AddMinutes(5)),
+            e4 = Some.InformationEvent(e1.Timestamp.AddMinutes(31));
+        LogEvent[] logEvents = new[] { e1, e2, e3, e4 };
+        
+        foreach (var logEvent in logEvents)
+        {
+            Clock.SetTestDateTimeNow(logEvent.Timestamp.DateTime);
+            log.Write(logEvent);
+        }
+
+        var files = Directory.GetFiles(temp.Path)
+            .OrderBy(p => p, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        var pattern = "yyyyMMddHHmm";
+
+        Assert.Equal(6, files.Length);
+        // Successful write of e1:
+        Assert.True(files[0].EndsWith(ExpectedFileName(fileName, e1.Timestamp, pattern)), files[0]);
+        // Failing writes for e2, will be dropped and logged to SelfLog:
+        Assert.True(files[1].EndsWith("_001.txt"), files[1]);
+        Assert.True(files[2].EndsWith("_002.txt"), files[2]);
+        Assert.True(files[3].EndsWith("_003.txt"), files[3]);
+        // Successful write of e3:
+        Assert.True(files[4].EndsWith(ExpectedFileName(fileName, e3.Timestamp, pattern)), files[4]);
+        // Successful write of e4:
+        Assert.True(files[5].EndsWith(ExpectedFileName(fileName, e4.Timestamp, pattern)), files[5]);
+    }
+
+    [Fact]
+    public void WhenFirstOpeningFailedWithLockRetryDelayed30Minutes()
+    {
+        var fileName = Some.String() + ".txt";
+        using var temp = new TempFolder();
+        LogEvent e1 = Some.InformationEvent(new DateTime(2012, 10, 28)),
+            e2 = Some.InformationEvent(e1.Timestamp.AddSeconds(1)),
+            e3 = Some.InformationEvent(e1.Timestamp.AddMinutes(5)),
+            e4 = Some.InformationEvent(e1.Timestamp.AddMinutes(31));
+        LogEvent[] logEvents = new[] { e1, e2, e3, e4 };
+
+        using (var log = new LoggerConfiguration()
+                   .WriteTo.File(Path.Combine(temp.Path, fileName), rollOnFileSizeLimit: true, fileSizeLimitBytes: 1,
+                       rollingInterval: RollingInterval.Hour, hooks: new FailOpeningHook(true, 2, 3, 4))
+                   .CreateLogger())
+        {
+            foreach (var logEvent in logEvents)
+            {
+                Clock.SetTestDateTimeNow(logEvent.Timestamp.DateTime);
+                log.Write(logEvent);
+            }
+        }
+
+        var files = Directory.GetFiles(temp.Path)
+            .OrderBy(p => p, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        var pattern = "yyyyMMddHH";
+
+        foreach (var file in files)
+        {
+            _testOutputHelper.WriteLine(file + ": " + System.IO.File.ReadAllText(file));
+        }
+        Assert.Equal(5, files.Length);
+        // Successful write of e1:
+        Assert.True(files[0].EndsWith(ExpectedFileName(fileName, e1.Timestamp, pattern)), files[0]);
+        // Failing writes for e2, will be dropped and logged to SelfLog; on lock it will try it three times:
+        Assert.True(files[1].EndsWith("_001.txt"), files[1]);
+        Assert.True(files[2].EndsWith("_002.txt"), files[2]);
+        Assert.True(files[3].EndsWith("_003.txt"), files[3]);
+        /* e3 will be dropped and logged to SelfLog without new file as it's in the 30 minutes cooldown and roller only starts on next hour! */
+        // Successful write of e4:
+        Assert.True(files[4].EndsWith("_004.txt"), files[4]);
+    }
+
+    [Fact]
+    public void WhenFirstOpeningFailedWithoutLockRetryDelayed30Minutes()
+    {
+        var fileName = Some.String() + ".txt";
+        using var temp = new TempFolder();
+        LogEvent e1 = Some.InformationEvent(new DateTime(2012, 10, 28)),
+            e2 = Some.InformationEvent(e1.Timestamp.AddSeconds(1)),
+            e3 = Some.InformationEvent(e1.Timestamp.AddMinutes(5)),
+            e4 = Some.InformationEvent(e1.Timestamp.AddMinutes(31));
+        LogEvent[] logEvents = new[] { e1, e2, e3, e4 };
+
+        using (var log = new LoggerConfiguration()
+                   .WriteTo.File(Path.Combine(temp.Path, fileName), rollOnFileSizeLimit: true, fileSizeLimitBytes: 1,
+                       rollingInterval: RollingInterval.Hour, hooks: new FailOpeningHook(false, 2))
+                   .CreateLogger())
+        {
+            foreach (var logEvent in logEvents)
+            {
+                Clock.SetTestDateTimeNow(logEvent.Timestamp.DateTime);
+                log.Write(logEvent);
+            }
+        }
+
+        var files = Directory.GetFiles(temp.Path)
+            .OrderBy(p => p, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        var pattern = "yyyyMMddHH";
+
+        foreach (var file in files)
+        {
+            _testOutputHelper.WriteLine(file + ": " + System.IO.File.ReadAllText(file));
+        }
+        Assert.Equal(3, files.Length);
+        // Successful write of e1:
+        Assert.True(files[0].EndsWith(ExpectedFileName(fileName, e1.Timestamp, pattern)), files[0]);
+        // Failing writes for e2, will be dropped and logged to SelfLog; on non-lock it will try it once:
+        Assert.True(files[1].EndsWith("_001.txt"), files[1]);
+        /* e3 will be dropped and logged to SelfLog without new file as it's in the 30 minutes cooldown and roller only starts on next hour! */
+        // Successful write of e4:
+        Assert.True(files[2].EndsWith("_002.txt"), files[2]);
+    }
+
+    [Fact]
     public void WhenSizeLimitIsBreachedNewFilesCreated()
     {
         var fileName = Some.String() + ".txt";
@@ -279,7 +411,7 @@ public class RollingFileSinkTests
                 Clock.SetTestDateTimeNow(@event.Timestamp.DateTime);
                 log.Write(@event);
 
-                var expected = pathFormat.Replace(".txt", @event.Timestamp.ToString("yyyyMMdd") + ".txt");
+                var expected = ExpectedFileName(pathFormat, @event.Timestamp, "yyyyMMdd");
                 Assert.True(System.IO.File.Exists(expected));
 
                 verified.Add(expected);
@@ -291,5 +423,10 @@ public class RollingFileSinkTests
             verifyWritten?.Invoke(verified);
             Directory.Delete(folder, true);
         }
+    }
+
+    static string ExpectedFileName(string fileName, DateTimeOffset timestamp, string pattern)
+    {
+        return fileName.Replace(".txt", timestamp.ToString(pattern) + ".txt");
     }
 }

--- a/test/Serilog.Sinks.File.Tests/RollingFileSinkTests.cs
+++ b/test/Serilog.Sinks.File.Tests/RollingFileSinkTests.cs
@@ -9,13 +9,18 @@ using Xunit.Abstractions;
 
 namespace Serilog.Sinks.File.Tests;
 
-public class RollingFileSinkTests
+public class RollingFileSinkTests : IDisposable
 {
     private readonly ITestOutputHelper _testOutputHelper;
 
     public RollingFileSinkTests(ITestOutputHelper testOutputHelper)
     {
         _testOutputHelper = testOutputHelper;
+    }
+
+    public void Dispose()
+    {
+        SelfLog.Disable();
     }
 
     [Fact]

--- a/test/Serilog.Sinks.File.Tests/Support/FailOpeningHook.cs
+++ b/test/Serilog.Sinks.File.Tests/Support/FailOpeningHook.cs
@@ -1,0 +1,36 @@
+using System.Text;
+
+namespace Serilog.Sinks.File.Tests.Support;
+
+/// <inheritdoc />
+/// <summary>
+/// Demonstrates the use of <seealso cref="T:Serilog.FileLifecycleHooks" />, by failing to open for the given amount of times.
+/// </summary>
+class FailOpeningHook : FileLifecycleHooks
+{
+    readonly bool _asFileLocked;
+    readonly int[] _failingInstances;
+
+    public int TimesOpened { get; private set; }
+
+    public FailOpeningHook(bool asFileLocked, params int[] failingInstances)
+    {
+        _asFileLocked = asFileLocked;
+        _failingInstances = failingInstances;
+    }
+
+    public override Stream OnFileOpened(string path, Stream _, Encoding __)
+    {
+        TimesOpened++;
+        if (_failingInstances.Contains(TimesOpened))
+        {
+            var message = $"We failed on try {TimesOpened}, the file was locked: {_asFileLocked}";
+            
+            throw _asFileLocked
+                ? new IOException(message)
+                : new Exception(message);
+        }
+
+        return base.OnFileOpened(path, _, __);
+    }
+}

--- a/test/Serilog.Sinks.File.Tests/Support/FailOpeningHook.cs
+++ b/test/Serilog.Sinks.File.Tests/Support/FailOpeningHook.cs
@@ -19,18 +19,18 @@ class FailOpeningHook : FileLifecycleHooks
         _failingInstances = failingInstances;
     }
 
-    public override Stream OnFileOpened(string path, Stream _, Encoding __)
+    public override Stream OnFileOpened(string path, Stream stream, Encoding encoding)
     {
         TimesOpened++;
         if (_failingInstances.Contains(TimesOpened))
         {
             var message = $"We failed on try {TimesOpened}, the file was locked: {_asFileLocked}";
-            
+
             throw _asFileLocked
                 ? new IOException(message)
                 : new Exception(message);
         }
 
-        return base.OnFileOpened(path, _, __);
+        return base.OnFileOpened(path, stream, encoding);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/serilog/serilog-sinks-file/issues/334

I also added a check to `Emit` that writes to `SelfLog` if the log was dropped. This could have happend also before if the file was locked 3 times or any other exception was thrown due to checking for `_currentFile?.EmitOrOverflow(logEvent) == false` and not `_currentFile?.EmitOrOverflow(logEvent) != true` but it was hard to find out that it got dropped. But since the code seems to do this intentional to avoid blocking and force-retrying after 30 minutes (or on next checkpoint), that should be correct.

I encapsulated everything into a `try-finally` block to ensure that this happens on ANY exception. The old code was also waiting until the next checkpoint. So if that was daily, it would drop ALL logs for the rest of the day. With my adjustment (to checking if 30 minutes is less than the next checkpoint) it will also cover the case that no rolling was setup OR that it would be longer than 30 minutes.