### PR TITLE
Added support for customising date in filename

### DIFF
--- a/test/Serilog.Sinks.File.Tests/RollingFileSinkTests.cs
+++ b/test/Serilog.Sinks.File.Tests/RollingFileSinkTests.cs
@@ -30,6 +30,23 @@ public class RollingFileSinkTests : IDisposable
     }
 
     [Fact]
+    public void ShouldCreateFileWithDatePlaceHolder()
+    {
+        var config = new LoggerConfiguration()
+            .WriteTo.File("{Date}-log.txt", rollingInterval: RollingInterval.Day);
+        var log = config.CreateLogger();
+
+        var now = new DateTime(2013, 7, 14, 3, 24, 9, 980);
+
+        Clock.SetTestDateTimeNow(now);
+        log.Write(Some.InformationEvent());
+
+        var path = Path.Combine(Directory.GetCurrentDirectory(), "20130714-log.txt");
+
+        Assert.True(System.IO.File.Exists(path));
+    }
+
+    [Fact]
     public void EventsAreWrittenWhenSharingIsEnabled()
     {
         TestRollingEventSequence(
@@ -172,7 +189,7 @@ public class RollingFileSinkTests : IDisposable
             e3 = Some.InformationEvent(e1.Timestamp.AddMinutes(5)),
             e4 = Some.InformationEvent(e1.Timestamp.AddMinutes(31));
         LogEvent[] logEvents = new[] { e1, e2, e3, e4 };
-        
+
         foreach (var logEvent in logEvents)
         {
             Clock.SetTestDateTimeNow(logEvent.Timestamp.DateTime);
@@ -210,7 +227,7 @@ public class RollingFileSinkTests : IDisposable
             e3 = Some.InformationEvent(e1.Timestamp.AddMinutes(5)),
             e4 = Some.InformationEvent(e1.Timestamp.AddMinutes(31));
         LogEvent[] logEvents = new[] { e1, e2, e3, e4 };
-        
+
         SelfLog.Enable(_testOutputHelper.WriteLine);
         foreach (var logEvent in logEvents)
         {
@@ -247,7 +264,7 @@ public class RollingFileSinkTests : IDisposable
             e3 = Some.InformationEvent(e1.Timestamp.AddMinutes(5)),
             e4 = Some.InformationEvent(e1.Timestamp.AddMinutes(31));
         LogEvent[] logEvents = new[] { e1, e2, e3, e4 };
-        
+
         SelfLog.Enable(_testOutputHelper.WriteLine);
         foreach (var logEvent in logEvents)
         {

--- a/test/Serilog.Sinks.File.Tests/TemplatedPathRollerTests.cs
+++ b/test/Serilog.Sinks.File.Tests/TemplatedPathRollerTests.cs
@@ -1,9 +1,42 @@
-﻿using Xunit;
+﻿using System.Globalization;
+using Xunit;
 
 namespace Serilog.Sinks.File.Tests;
 
 public class PathRollerTests
 {
+    [Theory]
+    [InlineData(null)]
+    [InlineData(2)]
+    public void GetLogFilePath_WhenPathContainsDateTokenAtStart_ShouldReplaceDateToken(int? sequenceNumber)
+    {
+        var now = new DateTime(2013, 7, 14, 3, 24, 9, 980);
+        string expectedName = sequenceNumber is null
+            ? $"{now:yyyyMMdd}-logs.txt"
+            : $"{now:yyyyMMdd}_{sequenceNumber.Value.ToString("000", CultureInfo.InvariantCulture)}-logs.txt";
+
+        var roller = new PathRoller(Path.Combine("Logs", "{date}-logs.txt"), RollingInterval.Day);
+        roller.GetLogFilePath(now, sequenceNumber, out string actualName);
+
+        AssertEqualAbsolute(Path.Combine("Logs", expectedName), actualName);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(2)]
+    public void GetLogFilePath_WhenPathContainsDateTokenAtEnd_ShouldReplaceDateToken(int? sequenceNumber)
+    {
+        var now = new DateTime(2013, 7, 14, 3, 24, 9, 980);
+        string expectedName = sequenceNumber is null
+            ? $"logs-{now:yyyyMMdd}.txt"
+            : $"logs-{now:yyyyMMdd}_{sequenceNumber.Value.ToString("000", CultureInfo.InvariantCulture)}.txt";
+
+        var roller = new PathRoller(Path.Combine("Logs", "logs-{Date}.txt"), RollingInterval.Day);
+        roller.GetLogFilePath(now, sequenceNumber, out string actualName);
+
+        AssertEqualAbsolute(Path.Combine("Logs", expectedName), actualName);
+    }
+
     [Fact]
     public void TheLogFileIncludesDateToken()
     {
@@ -22,6 +55,15 @@ public class PathRollerTests
         AssertEqualAbsolute(Path.Combine("Logs", "log-20130714_012.txt"), path);
     }
 
+    [Fact]
+    public void ANonZeroIncrementIsIncludedAndPaddedWhenDatePlaceHolderExists()
+    {
+        var roller = new PathRoller(Path.Combine("Logs", "{Date}-log.txt"), RollingInterval.Day);
+        var now = new DateTime(2013, 7, 14, 3, 24, 9, 980);
+        roller.GetLogFilePath(now, 12, out var path);
+        AssertEqualAbsolute(Path.Combine("Logs", "20130714_012-log.txt"), path);
+    }
+
     static void AssertEqualAbsolute(string path1, string path2)
     {
         var abs1 = Path.GetFullPath(path1);
@@ -37,12 +79,28 @@ public class PathRollerTests
     }
 
     [Fact]
+    public void TheRollerReturnsTheLogFileDirectoryWhenDatePlaceHolderExists()
+    {
+        var roller = new PathRoller(Path.Combine("Logs", "{Date}-log.txt"), RollingInterval.Day);
+        AssertEqualAbsolute("Logs", roller.LogFileDirectory);
+    }
+
+    [Fact]
     public void TheLogFileIsNotRequiredToIncludeAnExtension()
     {
         var roller = new PathRoller(Path.Combine("Logs", "log-"), RollingInterval.Day);
         var now = new DateTime(2013, 7, 14, 3, 24, 9, 980);
         roller.GetLogFilePath(now, null, out var path);
         AssertEqualAbsolute(Path.Combine("Logs", "log-20130714"), path);
+    }
+
+    [Fact]
+    public void TheLogFileIsNotRequiredToIncludeAnExtensionWhenDatePlaceHolderExists()
+    {
+        var roller = new PathRoller(Path.Combine("Logs", "{Date}-log"), RollingInterval.Day);
+        var now = new DateTime(2013, 7, 14, 3, 24, 9, 980);
+        roller.GetLogFilePath(now, null, out var path);
+        AssertEqualAbsolute(Path.Combine("Logs", "20130714-log"), path);
     }
 
     [Fact]
@@ -55,12 +113,23 @@ public class PathRollerTests
     }
 
     [Fact]
+    public void TheLogFileIsNotRequiredToIncludeADirectoryWhenDatePlaceHolderExists()
+    {
+        var roller = new PathRoller("{Date}-log", RollingInterval.Day);
+        var now = new DateTime(2013, 7, 14, 3, 24, 9, 980);
+        roller.GetLogFilePath(now, null, out var path);
+        AssertEqualAbsolute("20130714-log", path);
+    }
+
+    [Fact]
     public void MatchingExcludesSimilarButNonMatchingFiles()
     {
         var roller = new PathRoller("log-.txt", RollingInterval.Day);
         const string similar1 = "log-0.txt";
         const string similar2 = "log-hello.txt";
-        var matched = roller.SelectMatches(new[] { similar1, similar2 });
+        const string similar3 = "0-log.txt";
+        const string similar4 = "hello-log.txt";
+        var matched = roller.SelectMatches(new[] { similar1, similar2, similar3, similar4 });
         Assert.Empty(matched);
     }
 
@@ -71,9 +140,17 @@ public class PathRollerTests
         Assert.Equal("log-*.txt", roller.DirectorySearchPattern);
     }
 
+    [Fact]
+    public void TheDirectorSearchPatternUsesWildcardInPlaceOfDateWhenDatePlaceHolderExists()
+    {
+        var roller = new PathRoller(Path.Combine("Logs", "{Date}-log.txt"), RollingInterval.Day);
+        Assert.Equal("*-log.txt", roller.DirectorySearchPattern);
+    }
+
     [Theory]
     [InlineData("log-.txt", "log-20131210.txt", "log-20131210_031.txt", RollingInterval.Day)]
     [InlineData("log-.txt", "log-2013121013.txt", "log-2013121013_031.txt", RollingInterval.Hour)]
+    [InlineData("{Date}-log.txt", "2013121013-log.txt", "2013121013_031-log.txt", RollingInterval.Hour)]
     public void MatchingSelectsFiles(string template, string zeroth, string thirtyFirst, RollingInterval interval)
     {
         var roller = new PathRoller(template, interval);
@@ -86,6 +163,7 @@ public class PathRollerTests
     [Theory]
     [InlineData("log-.txt", "log-20150101.txt", "log-20141231.txt", RollingInterval.Day)]
     [InlineData("log-.txt", "log-2015010110.txt", "log-2015010109.txt", RollingInterval.Hour)]
+    [InlineData("{Date}-log.txt", "2015010110-log.txt", "2015010109-log.txt", RollingInterval.Hour)]
     public void MatchingParsesSubstitutions(string template, string newer, string older, RollingInterval interval)
     {
         var roller = new PathRoller(template, interval);


### PR DESCRIPTION
Address (Partially): #243 

Changes: 

- PathRoller now recognizes and uses {Date} placeholder in file name.
- Regex matching and directory search patterns have been adjusted for use with {Date} placeholder

This update should Enable users to use following configuration: 

```
var config = new LoggerConfiguration()
            .WriteTo.File("{Date}-log.txt", rollingInterval: RollingInterval.Day);
var log = config.CreateLogger();
```

Unit Tests Added and Updated in:

- TemplatePathRollerTests
- RollingFileSinkTests