### PR TITLE
Add ability for static base file and customizable file roll patterns.

### DIFF
--- a/src/Serilog.Sinks.File/FileLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.File/FileLoggerConfigurationExtensions.cs
@@ -155,7 +155,8 @@ public static class FileLoggerConfigurationExtensions
         Encoding encoding)
     {
         return File(sinkConfiguration, path, restrictedToMinimumLevel, outputTemplate, formatProvider, fileSizeLimitBytes, levelSwitch, buffered,
-            shared, flushToDiskInterval, rollingInterval, rollOnFileSizeLimit, retainedFileCountLimit, encoding, null);
+            shared, flushToDiskInterval, rollingInterval, rollOnFileSizeLimit, retainedFileCountLimit, encoding, null,
+             null);
     }
 
     /// <summary>
@@ -164,7 +165,7 @@ public static class FileLoggerConfigurationExtensions
     /// <param name="sinkConfiguration">Logger sink configuration.</param>
     /// <param name="formatter">A formatter, such as <see cref="JsonFormatter"/>, to convert the log events into
     /// text for the file. If control of regular text formatting is required, use the other
-    /// overload of <see cref="File(LoggerSinkConfiguration, string, LogEventLevel, string, IFormatProvider, long?, LoggingLevelSwitch, bool, bool, TimeSpan?, RollingInterval, bool, int?, Encoding, FileLifecycleHooks, TimeSpan?)"/>
+    /// overload of <see cref="File(LoggerSinkConfiguration, string, LogEventLevel, string, IFormatProvider, long?, LoggingLevelSwitch, bool, bool, TimeSpan?, RollingInterval, bool, int?, Encoding, FileLifecycleHooks, TimeSpan?, bool, Func{DateTime?,string}?, string?)"/>
     /// and specify the outputTemplate parameter instead.
     /// </param>
     /// <param name="path">Path to the file.</param>
@@ -236,6 +237,11 @@ public static class FileLoggerConfigurationExtensions
     /// Must be greater than or equal to <see cref="TimeSpan.Zero"/>.
     /// Ignored if <paramref see="rollingInterval"/> is <see cref="RollingInterval.Infinite"/>.
     /// The default is to retain files indefinitely.</param>
+    /// <param name="keepPathStaticOnRoll">Use the initial file path as a static file.</param>
+    /// <param name="customFormatFunc">A custom function that returns a custom string for rolling over files.
+    /// Accepts a DateTime for using custom DateTime formats.
+    /// This must return a string that can be matched by <paramref name="customRollPattern"/>.</param>
+    /// <param name="customRollPattern">A custom pattern for rolling over files. This must compile into a <see cref="System.Text.RegularExpressions.Regex"/> </param>
     /// <returns>Configuration object allowing method chaining.</returns>
     /// <exception cref="ArgumentNullException">When <paramref name="sinkConfiguration"/> is <code>null</code></exception>
     /// <exception cref="ArgumentNullException">When <paramref name="path"/> is <code>null</code></exception>
@@ -262,7 +268,10 @@ public static class FileLoggerConfigurationExtensions
         int? retainedFileCountLimit = DefaultRetainedFileCountLimit,
         Encoding? encoding = null,
         FileLifecycleHooks? hooks = null,
-        TimeSpan? retainedFileTimeLimit = null)
+        TimeSpan? retainedFileTimeLimit = null,
+        bool keepPathStaticOnRoll = false,
+        Func<DateTime?,string>? customFormatFunc = null,
+        string? customRollPattern = null)
     {
         if (sinkConfiguration == null) throw new ArgumentNullException(nameof(sinkConfiguration));
         if (path == null) throw new ArgumentNullException(nameof(path));
@@ -271,7 +280,7 @@ public static class FileLoggerConfigurationExtensions
         var formatter = new MessageTemplateTextFormatter(outputTemplate, formatProvider);
         return File(sinkConfiguration, formatter, path, restrictedToMinimumLevel, fileSizeLimitBytes,
             levelSwitch, buffered, shared, flushToDiskInterval,
-            rollingInterval, rollOnFileSizeLimit, retainedFileCountLimit, encoding, hooks, retainedFileTimeLimit);
+            rollingInterval, rollOnFileSizeLimit, retainedFileCountLimit, encoding, hooks, retainedFileTimeLimit, keepPathStaticOnRoll, customFormatFunc, customRollPattern);
     }
 
     /// <summary>
@@ -280,7 +289,7 @@ public static class FileLoggerConfigurationExtensions
     /// <param name="sinkConfiguration">Logger sink configuration.</param>
     /// <param name="formatter">A formatter, such as <see cref="JsonFormatter"/>, to convert the log events into
     /// text for the file. If control of regular text formatting is required, use the other
-    /// overload of <see cref="File(LoggerSinkConfiguration, string, LogEventLevel, string, IFormatProvider, long?, LoggingLevelSwitch, bool, bool, TimeSpan?, RollingInterval, bool, int?, Encoding, FileLifecycleHooks, TimeSpan?)"/>
+    /// overload of <see cref="File(LoggerSinkConfiguration, string, LogEventLevel, string, IFormatProvider, long?, LoggingLevelSwitch, bool, bool, TimeSpan?, RollingInterval, bool, int?, Encoding, FileLifecycleHooks, TimeSpan?, bool, Func{DateTime?, string}?, string?)"/>
     /// and specify the outputTemplate parameter instead.
     /// </param>
     /// <param name="path">Path to the file.</param>
@@ -306,6 +315,9 @@ public static class FileLoggerConfigurationExtensions
     /// Must be greater than or equal to <see cref="TimeSpan.Zero"/>.
     /// Ignored if <paramref see="rollingInterval"/> is <see cref="RollingInterval.Infinite"/>.
     /// The default is to retain files indefinitely.</param>
+    /// <param name="keepPathStaticOnRoll">Use the initial file path as a static file.</param>
+    /// <param name="customFormatFunc">A custom function that returns a custom string for rolling over files. This must return a string that can be matched by <paramref name="customRollPattern"/>.</param>
+    /// <param name="customRollPattern">A custom pattern for rolling over files. This must compile into a <see cref="System.Text.RegularExpressions.Regex"/> </param>
     /// <returns>Configuration object allowing method chaining.</returns>
     /// <exception cref="ArgumentNullException">When <paramref name="sinkConfiguration"/> is <code>null</code></exception>
     /// <exception cref="ArgumentNullException">When <paramref name="formatter"/> is <code>null</code></exception>
@@ -331,7 +343,10 @@ public static class FileLoggerConfigurationExtensions
         int? retainedFileCountLimit = DefaultRetainedFileCountLimit,
         Encoding? encoding = null,
         FileLifecycleHooks? hooks = null,
-        TimeSpan? retainedFileTimeLimit = null)
+        TimeSpan? retainedFileTimeLimit = null,
+        bool keepPathStaticOnRoll = false,
+        Func<DateTime?,string>? customFormatFunc = null,
+        string? customRollPattern = null)
     {
         if (sinkConfiguration == null) throw new ArgumentNullException(nameof(sinkConfiguration));
         if (formatter == null) throw new ArgumentNullException(nameof(formatter));
@@ -339,7 +354,7 @@ public static class FileLoggerConfigurationExtensions
 
         return ConfigureFile(sinkConfiguration.Sink, formatter, path, restrictedToMinimumLevel, fileSizeLimitBytes, levelSwitch,
             buffered, false, shared, flushToDiskInterval, encoding, rollingInterval, rollOnFileSizeLimit,
-            retainedFileCountLimit, hooks, retainedFileTimeLimit);
+            retainedFileCountLimit, hooks, retainedFileTimeLimit, keepPathStaticOnRoll, customFormatFunc, customRollPattern);
     }
 
     /// <summary>
@@ -487,14 +502,15 @@ public static class FileLoggerConfigurationExtensions
         LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
         LoggingLevelSwitch? levelSwitch = null,
         Encoding? encoding = null,
-        FileLifecycleHooks? hooks = null)
+        FileLifecycleHooks? hooks = null
+        )
     {
         if (sinkConfiguration == null) throw new ArgumentNullException(nameof(sinkConfiguration));
         if (formatter == null) throw new ArgumentNullException(nameof(formatter));
         if (path == null) throw new ArgumentNullException(nameof(path));
 
         return ConfigureFile(sinkConfiguration.Sink, formatter, path, restrictedToMinimumLevel, null, levelSwitch, false, true,
-            false, null, encoding, RollingInterval.Infinite, false, null, hooks, null);
+            false, null, encoding, RollingInterval.Infinite, false, null, hooks, null, false, null, null);
     }
 
     static LoggerConfiguration ConfigureFile(
@@ -513,7 +529,10 @@ public static class FileLoggerConfigurationExtensions
         bool rollOnFileSizeLimit,
         int? retainedFileCountLimit,
         FileLifecycleHooks? hooks,
-        TimeSpan? retainedFileTimeLimit)
+        TimeSpan? retainedFileTimeLimit,
+        bool keepPathStaticOnRoll,
+        Func<DateTime?,string>? customFormatFunc,
+        string? customRollPattern)
     {
         if (addSink == null) throw new ArgumentNullException(nameof(addSink));
         if (formatter == null) throw new ArgumentNullException(nameof(formatter));
@@ -523,6 +542,7 @@ public static class FileLoggerConfigurationExtensions
         if (retainedFileTimeLimit.HasValue && retainedFileTimeLimit < TimeSpan.Zero) throw new ArgumentException("Negative value provided; retained file time limit must be non-negative.", nameof(retainedFileTimeLimit));
         if (shared && buffered) throw new ArgumentException("Buffered writes are not available when file sharing is enabled.", nameof(buffered));
         if (shared && hooks != null) throw new ArgumentException("File lifecycle hooks are not currently supported for shared log files.", nameof(hooks));
+        if(keepPathStaticOnRoll && (fileSizeLimitBytes == null && rollingInterval == RollingInterval.Infinite )) throw new ArgumentException("keepPathStaticOnRoll is only supported when either fileSizeLimitBytes or rollingInterval are enabled");
 
         ILogEventSink sink;
 
@@ -530,7 +550,7 @@ public static class FileLoggerConfigurationExtensions
         {
             if (rollOnFileSizeLimit || rollingInterval != RollingInterval.Infinite)
             {
-                sink = new RollingFileSink(path, formatter, fileSizeLimitBytes, retainedFileCountLimit, encoding, buffered, shared, rollingInterval, rollOnFileSizeLimit, hooks, retainedFileTimeLimit);
+                sink = new RollingFileSink(path, formatter, fileSizeLimitBytes, retainedFileCountLimit, encoding, buffered, shared, rollingInterval, rollOnFileSizeLimit, hooks, retainedFileTimeLimit, keepPathStaticOnRoll, customFormatFunc, customRollPattern);
             }
             else
             {

--- a/src/Serilog.Sinks.File/Sinks/File/RollingFileSink.cs
+++ b/src/Serilog.Sinks.File/Sinks/File/RollingFileSink.cs
@@ -196,7 +196,7 @@ sealed class RollingFileSink : ILogEventSink, IFlushableFileSink, IDisposable, I
                     _roller.GetLogFilePath(now, sequence, out path, out var copyPath);
                     if (copyPath != null && System.IO.File.Exists(path))
                     {
-                        System.IO.File.Copy(path, copyPath);
+                        System.IO.File.Move(path, copyPath);
                     }
                 }
                 else

--- a/src/Serilog.Sinks.File/Sinks/File/RollingFileSink.cs
+++ b/src/Serilog.Sinks.File/Sinks/File/RollingFileSink.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Globalization;
 using System.Text;
 using Serilog.Core;
 using Serilog.Debugging;
@@ -31,7 +32,9 @@ sealed class RollingFileSink : ILogEventSink, IFlushableFileSink, IDisposable, I
     readonly bool _buffered;
     readonly bool _shared;
     readonly bool _rollOnFileSizeLimit;
+    readonly bool _keepPathAsStaticFile;
     readonly FileLifecycleHooks? _hooks;
+    readonly Func<DateTime?, string>? _customFormatFunc;
 
     ILoggingFailureListener _failureListener = SelfLog.FailureListener;
 
@@ -51,14 +54,18 @@ sealed class RollingFileSink : ILogEventSink, IFlushableFileSink, IDisposable, I
                           RollingInterval rollingInterval,
                           bool rollOnFileSizeLimit,
                           FileLifecycleHooks? hooks,
-                          TimeSpan? retainedFileTimeLimit)
+                          TimeSpan? retainedFileTimeLimit,
+                          bool keepPathAsStaticFile,
+                          Func<DateTime?, string>? customFormatFunc,
+                          string? customRollPattern)
     {
         if (path == null) throw new ArgumentNullException(nameof(path));
         if (fileSizeLimitBytes is < 1) throw new ArgumentException("Invalid value provided; file size limit must be at least 1 byte, or null.");
         if (retainedFileCountLimit is < 1) throw new ArgumentException("Zero or negative value provided; retained file count limit must be at least 1.");
         if (retainedFileTimeLimit.HasValue && retainedFileTimeLimit < TimeSpan.Zero) throw new ArgumentException("Negative value provided; retained file time limit must be non-negative.", nameof(retainedFileTimeLimit));
+        if(customFormatFunc != null && customRollPattern == null) throw new ArgumentException("When Supplying a Custom Format Function, a Custom Roll Pattern must also be supplied.");
 
-        _roller = new PathRoller(path, rollingInterval);
+        _roller = new PathRoller(path, rollingInterval, keepPathAsStaticFile, customFormatFunc, customRollPattern);
         _textFormatter = textFormatter;
         _fileSizeLimitBytes = fileSizeLimitBytes;
         _retainedFileCountLimit = retainedFileCountLimit;
@@ -68,6 +75,8 @@ sealed class RollingFileSink : ILogEventSink, IFlushableFileSink, IDisposable, I
         _shared = shared;
         _rollOnFileSizeLimit = rollOnFileSizeLimit;
         _hooks = hooks;
+        _keepPathAsStaticFile = keepPathAsStaticFile;
+        _customFormatFunc = customFormatFunc;
     }
 
     public void Emit(LogEvent logEvent)
@@ -163,10 +172,37 @@ sealed class RollingFileSink : ILogEventSink, IFlushableFileSink, IDisposable, I
                     sequence = minSequence;
             }
 
+            if (sequence != null)
+            {
+                _roller.GetLogFilePath(now, sequence, out var p, out var c);
+                switch (_keepPathAsStaticFile)
+                {
+                    // var path = Path.Combine(_roller.LogFileDirectory, $"{_roller.PathRollerPrefix}{_customFormatFunc?.Invoke()}_{sequence.Value.ToString("000", CultureInfo.InvariantCulture)}{_roller.DirectorySearchPattern}");
+                    case true when System.IO.File.Exists(c):
+                        sequence++;
+                        break;
+                    case false when _customFormatFunc != null && !System.IO.File.Exists(p):
+                        sequence = 1;
+                        break;
+                }
+            }
+
             const int maxAttempts = 3;
             for (var attempt = 0; attempt < maxAttempts; attempt++)
             {
-                _roller.GetLogFilePath(now, sequence, out var path);
+                string path;
+                if (_keepPathAsStaticFile)
+                {
+                    _roller.GetLogFilePath(now, sequence, out path, out var copyPath);
+                    if (copyPath != null && System.IO.File.Exists(path))
+                    {
+                        System.IO.File.Copy(path, copyPath);
+                    }
+                }
+                else
+                {
+                    _roller.GetLogFilePath(now, sequence, out path);
+                }
 
                 try
                 {
@@ -176,7 +212,7 @@ sealed class RollingFileSink : ILogEventSink, IFlushableFileSink, IDisposable, I
                         new SharedFileSink(path, _textFormatter, _fileSizeLimitBytes, _encoding)
                         :
 #pragma warning restore 618
-                        new FileSink(path, _textFormatter, _fileSizeLimitBytes, _encoding, _buffered, _hooks);
+                        new FileSink(path, _textFormatter, _fileSizeLimitBytes, _encoding, _buffered, _hooks, _keepPathAsStaticFile);
 
                     _currentFileSequence = sequence;
 


### PR DESCRIPTION
In my work, a number of our projects use Serilog. One project has a task to revamp the logging to use items like Elastic/FluentD, but must also still output to a static file for developer/support engineer use in the field. 

Given that a number of projects were using Serilog, this seemed an easier feature to add than to figure out other logging libraries/roll our own. Other sinks forked off of this removed the NETStandard 2.0 compatibility, which was a no-go for use on our end. 

Did this in my own time both to help my work, but to have something I can use outside of work on my tinkering projects. 

Adds 3 optional parameters: 
 - **keepPathStaticOnRoll** (`bool`) - Keep the base file name passed in (`log.txt` for instance) as the base file. 
 - **customFormatFunc** (`Func<DateTime?,string>`) - Function to give a custom format for rolling files. The yyyyMMDD format did not work for requirements. 
 - **customRollPattern** (`string`) - A string regex pattern that will match the output of customFormatFunc. This must be provided when custom format is used, as the rollovers will not work (nor will it validate). 

