### PR TITLE
Change constants to public in FileLoggerConfigurationExtensions

### DIFF
--- a/src/Serilog.Sinks.File/FileLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.File/FileLoggerConfigurationExtensions.cs
@@ -30,9 +30,9 @@ namespace Serilog;
 /// <summary>Extends <see cref="LoggerConfiguration"/> with methods to add file sinks.</summary>
 public static class FileLoggerConfigurationExtensions
 {
-    const int DefaultRetainedFileCountLimit = 31; // A long month of logs
-    const long DefaultFileSizeLimitBytes = 1L * 1024 * 1024 * 1024; // 1GB
-    const string DefaultOutputTemplate = "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message:lj}{NewLine}{Exception}";
+    public const int DefaultRetainedFileCountLimit = 31; // A long month of logs
+    public const long DefaultFileSizeLimitBytes = 1L * 1024 * 1024 * 1024; // 1GB
+    public const string DefaultOutputTemplate = "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message:lj}{NewLine}{Exception}";
 
     /// <summary>
     /// Write log events to the specified file.


### PR DESCRIPTION
Proposal: scope the default values to public, so that consuming applications may more easily subclass `MessageTemplateTextFormatter` as a side-by-side for `JsonFormatter`.

Example usage under the current construct (brittle):
```
using System.Reflection;
using Serilog;
using Serilog.Formatting.Display;

namespace TestProject.Intexx.Extensions.Logging.Text
{
  public class TextFormatter : MessageTemplateTextFormatter
  {
    public TextFormatter() : base(DefaultTemplate) {}

    private static string DefaultTemplate
    {
      get
      {
        return typeof(FileLoggerConfigurationExtensions).Assembly
          .GetType($"{nameof(Serilog)}.{nameof(FileLoggerConfigurationExtensions)}")
          .GetField("DefaultOutputTemplate", BindingFlags.NonPublic | BindingFlags.Static)
          .GetValue(null);
      }
    }
  }
}
```