### PR TITLE
Ability to delete log files and recreate them immediately

### DIFF
--- a/example/Sample-SharedFile/Program.cs
+++ b/example/Sample-SharedFile/Program.cs
@@ -1,0 +1,27 @@
+﻿using Serilog;
+using Serilog.Debugging;
+
+SelfLog.Enable(Console.Out);
+
+var sw = System.Diagnostics.Stopwatch.StartNew();
+
+Console.WriteLine("Running with shared=true...");
+sw.Restart();
+var sharedLogger = new LoggerConfiguration()
+    .WriteTo.File("log-shared.txt", shared: true)
+    .CreateLogger();
+
+for (var i = 0; i < 1000000; ++i)
+{
+    sharedLogger.Information("Hello, file logger!");
+}
+
+sharedLogger.Dispose();
+
+sw.Stop();
+Console.WriteLine($"Elapsed: {sw.ElapsedMilliseconds} ms");
+Console.WriteLine($"Size: {new FileInfo("log-shared.txt").Length}");
+
+Console.WriteLine("Press any key to delete the temporary log file...");
+Console.ReadKey(true);
+File.Delete("log-shared.txt");

--- a/example/Sample-SharedFile/Sample-SharedFile.csproj
+++ b/example/Sample-SharedFile/Sample-SharedFile.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net48;net8.0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Serilog.Sinks.File\Serilog.Sinks.File.csproj" />
+  </ItemGroup>
+
+</Project>
+

--- a/example/Sample-SharedFile/Sample-SharedFile.csproj
+++ b/example/Sample-SharedFile/Sample-SharedFile.csproj
@@ -1,11 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
     <TargetFrameworks>net48;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Serilog.Sinks.File\Serilog.Sinks.File.csproj" />
   </ItemGroup>

--- a/serilog-sinks-file.sln
+++ b/serilog-sinks-file.sln
@@ -27,14 +27,14 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Serilog.Sinks.File.Tests", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sample", "example\Sample\Sample.csproj", "{A34235A2-A717-4A1C-BF5C-F4A9E06E1260}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sample-SharedFile", "example\Sample-SharedFile\Sample-SharedFile.csproj", "{6E2FBAB9-A71F-40BF-8F6E-9CF4A8D50AE7}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{3827A9BD-6D28-4A12-B1C0-32A9BD246EA6}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{E5028523-6E46-4A86-AAB9-BF4B1FA5D41D}"
 	ProjectSection(SolutionItems) = preProject
 		.github\workflows\ci.yml = .github\workflows\ci.yml
 	EndProjectSection
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sample-SharedFile", "example\Sample-SharedFile\Sample-SharedFile.csproj", "{6E2FBAB9-A71F-40BF-8F6E-9CF4A8D50AE7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/serilog-sinks-file.sln
+++ b/serilog-sinks-file.sln
@@ -34,6 +34,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 		.github\workflows\ci.yml = .github\workflows\ci.yml
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sample-SharedFile", "example\Sample-SharedFile\Sample-SharedFile.csproj", "{6E2FBAB9-A71F-40BF-8F6E-9CF4A8D50AE7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -52,6 +54,10 @@ Global
 		{A34235A2-A717-4A1C-BF5C-F4A9E06E1260}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A34235A2-A717-4A1C-BF5C-F4A9E06E1260}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A34235A2-A717-4A1C-BF5C-F4A9E06E1260}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6E2FBAB9-A71F-40BF-8F6E-9CF4A8D50AE7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6E2FBAB9-A71F-40BF-8F6E-9CF4A8D50AE7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6E2FBAB9-A71F-40BF-8F6E-9CF4A8D50AE7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6E2FBAB9-A71F-40BF-8F6E-9CF4A8D50AE7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -61,6 +67,7 @@ Global
 		{3C2D8E01-5580-426A-BDD9-EC59CD98E618} = {7B927378-9F16-4F6F-B3F6-156395136646}
 		{A34235A2-A717-4A1C-BF5C-F4A9E06E1260} = {196B1544-C617-4D7C-96D1-628713BDD52A}
 		{E5028523-6E46-4A86-AAB9-BF4B1FA5D41D} = {3827A9BD-6D28-4A12-B1C0-32A9BD246EA6}
+		{6E2FBAB9-A71F-40BF-8F6E-9CF4A8D50AE7} = {196B1544-C617-4D7C-96D1-628713BDD52A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {EA0197B4-FCA8-4DF2-BF34-274FA41333D1}

--- a/src/Serilog.Sinks.File/Sinks/File/SharedFileSink.AtomicAppend.cs
+++ b/src/Serilog.Sinks.File/Sinks/File/SharedFileSink.AtomicAppend.cs
@@ -81,7 +81,7 @@ public sealed class SharedFileSink : IFileSink, IDisposable, ISetLoggingFailureL
             path,
             FileMode.Append,
             FileSystemRights.AppendData,
-            FileShare.ReadWrite,
+            FileShare.ReadWrite | FileShare.Delete,
             _fileStreamBufferLength,
             FileOptions.None);
 

--- a/src/Serilog.Sinks.File/Sinks/File/SharedFileSink.AtomicAppend.cs
+++ b/src/Serilog.Sinks.File/Sinks/File/SharedFileSink.AtomicAppend.cs
@@ -110,7 +110,23 @@ public sealed class SharedFileSink : IFileSink, IDisposable, ISetLoggingFailureL
                         _path,
                         FileMode.Append,
                         FileSystemRights.AppendData,
-                        FileShare.ReadWrite,
+                        FileShare.ReadWrite | FileShare.Delete,
+                            length,
+                            FileOptions.None);
+                        _fileStreamBufferLength = length;
+
+                        oldOutput.Dispose();
+                    }
+
+                    if (!System.IO.File.Exists(_path))
+                    {
+                        var oldOutput = _fileOutput;
+
+                        _fileOutput = new FileStream(
+                            _path,
+                            FileMode.Append,
+                            FileSystemRights.AppendData,
+                            FileShare.ReadWrite | FileShare.Delete,
                         length,
                         FileOptions.None);
                     _fileStreamBufferLength = length;

--- a/src/Serilog.Sinks.File/Sinks/File/SharedFileSink.OSMutex.cs
+++ b/src/Serilog.Sinks.File/Sinks/File/SharedFileSink.OSMutex.cs
@@ -97,6 +97,7 @@ public sealed class SharedFileSink : IFileSink, IDisposable, ISetLoggingFailureL
             {
                 if (!System.IO.File.Exists(_path))
                 {
+                    _output.Dispose();
                     _underlyingStream.Dispose();
                     _underlyingStream = System.IO.File.Open(_path, FileMode.Append, FileAccess.Write, FileShare.ReadWrite | FileShare.Delete);
                     _output = new StreamWriter(_underlyingStream, _encoding ?? new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));

--- a/src/Serilog.Sinks.File/Sinks/File/SharedFileSink.OSMutex.cs
+++ b/src/Serilog.Sinks.File/Sinks/File/SharedFileSink.OSMutex.cs
@@ -199,7 +199,6 @@ public sealed class SharedFileSink : IFileSink, IDisposable, ISetLoggingFailureL
     void ReopenOutputStream()
     {
         var oldOutput = _output;
-        var oldStream = _underlyingStream;
 
         _underlyingStream = System.IO.File.Open(_path, FileMode.Append, FileAccess.Write, FileShare.ReadWrite | FileShare.Delete);
         _output = new StreamWriter(_underlyingStream, _encoding ?? new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
@@ -207,7 +206,6 @@ public sealed class SharedFileSink : IFileSink, IDisposable, ISetLoggingFailureL
         try
         {
             oldOutput.Dispose();
-            oldStream.Dispose();
         }
         catch (Exception ex) when (ex is IOException or ObjectDisposedException)
         {

--- a/src/Serilog.Sinks.File/Sinks/File/SharedFileSink.OSMutex.cs
+++ b/src/Serilog.Sinks.File/Sinks/File/SharedFileSink.OSMutex.cs
@@ -30,6 +30,7 @@ public sealed class SharedFileSink : IFileSink, IDisposable, ISetLoggingFailureL
 {
     TextWriter _output;
     FileStream _underlyingStream;
+    Encoding? _encoding;
     readonly string _path;
     readonly ITextFormatter _textFormatter;
     readonly long? _fileSizeLimitBytes;
@@ -61,6 +62,7 @@ public sealed class SharedFileSink : IFileSink, IDisposable, ISetLoggingFailureL
     public SharedFileSink(string path, ITextFormatter textFormatter, long? fileSizeLimitBytes, Encoding? encoding = null)
     {
         _path = path ?? throw new ArgumentNullException(nameof(path));
+        _encoding = encoding;
         if (fileSizeLimitBytes is < 1)
             throw new ArgumentException("Invalid value provided; file size limit must be at least 1 byte, or null.");
         _textFormatter = textFormatter ?? throw new ArgumentNullException(nameof(textFormatter));
@@ -75,7 +77,7 @@ public sealed class SharedFileSink : IFileSink, IDisposable, ISetLoggingFailureL
         var mutexName = Path.GetFullPath(path).Replace(Path.DirectorySeparatorChar, ':') + MutexNameSuffix;
         _mutex = new Mutex(false, mutexName);
         _underlyingStream = System.IO.File.Open(path, FileMode.Append, FileAccess.Write, FileShare.ReadWrite | FileShare.Delete);
-        _output = new StreamWriter(_underlyingStream, encoding ?? new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        _output = new StreamWriter(_underlyingStream, _encoding ?? new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
     }
 
     bool IFileSink.EmitOrOverflow(LogEvent logEvent)
@@ -97,7 +99,7 @@ public sealed class SharedFileSink : IFileSink, IDisposable, ISetLoggingFailureL
                 {
                     _underlyingStream.Dispose();
                     _underlyingStream = System.IO.File.Open(_path, FileMode.Append, FileAccess.Write, FileShare.ReadWrite | FileShare.Delete);
-                    _output = new StreamWriter(_underlyingStream,  new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+                    _output = new StreamWriter(_underlyingStream, _encoding ?? new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
                 }
 
                 _underlyingStream.Seek(0, SeekOrigin.End);

--- a/src/Serilog.Sinks.File/Sinks/File/SharedFileSink.OSMutex.cs
+++ b/src/Serilog.Sinks.File/Sinks/File/SharedFileSink.OSMutex.cs
@@ -100,24 +100,38 @@ public sealed class SharedFileSink : IFileSink, IDisposable, ISetLoggingFailureL
                     ReopenOutputStream();
                 }
 
-                _underlyingStream.Seek(0, SeekOrigin.End);
-                if (_fileSizeLimitBytes != null)
+                try
                 {
-                    try
+                    _underlyingStream.Seek(0, SeekOrigin.End);
+                    if (_fileSizeLimitBytes != null)
                     {
                         if (_underlyingStream.Length >= _fileSizeLimitBytes.Value)
                             return false;
                     }
-                    catch (FileNotFoundException)
-                    {
-                        ReopenOutputStream();
-                    }
-                }
 
-                _textFormatter.Format(logEvent, _output);
-                _output.Flush();
-                _underlyingStream.Flush();
-                return true;
+                    _textFormatter.Format(logEvent, _output);
+                    _output.Flush();
+                    _underlyingStream.Flush();
+                    return true;
+                }
+                catch (FileNotFoundException)
+                {
+                    // File was deleted between the existence check and the write operation.
+                    // Reopen the stream and retry the operation.
+                    ReopenOutputStream();
+
+                    _underlyingStream.Seek(0, SeekOrigin.End);
+                    if (_fileSizeLimitBytes != null)
+                    {
+                        if (_underlyingStream.Length >= _fileSizeLimitBytes.Value)
+                            return false;
+                    }
+
+                    _textFormatter.Format(logEvent, _output);
+                    _output.Flush();
+                    _underlyingStream.Flush();
+                    return true;
+                }
             }
             finally
             {

--- a/src/Serilog.Sinks.File/Sinks/File/SharedFileSink.OSMutex.cs
+++ b/src/Serilog.Sinks.File/Sinks/File/SharedFileSink.OSMutex.cs
@@ -1,4 +1,4 @@
-// Copyright 2013-2019 Serilog Contributors
+﻿// Copyright 2013-2019 Serilog Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,8 +28,9 @@ namespace Serilog.Sinks.File;
 [Obsolete("This type will be removed from the public API in a future version; use `WriteTo.File(shared: true)` instead.")]
 public sealed class SharedFileSink : IFileSink, IDisposable, ISetLoggingFailureListener
 {
-    readonly TextWriter _output;
-    readonly FileStream _underlyingStream;
+    TextWriter _output;
+    FileStream _underlyingStream;
+    readonly string _path;
     readonly ITextFormatter _textFormatter;
     readonly long? _fileSizeLimitBytes;
     readonly object _syncRoot = new();
@@ -59,7 +60,7 @@ public sealed class SharedFileSink : IFileSink, IDisposable, ISetLoggingFailureL
     /// <exception cref="ArgumentException">Invalid <paramref name="path"/></exception>
     public SharedFileSink(string path, ITextFormatter textFormatter, long? fileSizeLimitBytes, Encoding? encoding = null)
     {
-        if (path == null) throw new ArgumentNullException(nameof(path));
+        _path = path ?? throw new ArgumentNullException(nameof(path));
         if (fileSizeLimitBytes is < 1)
             throw new ArgumentException("Invalid value provided; file size limit must be at least 1 byte, or null.");
         _textFormatter = textFormatter ?? throw new ArgumentNullException(nameof(textFormatter));
@@ -73,7 +74,7 @@ public sealed class SharedFileSink : IFileSink, IDisposable, ISetLoggingFailureL
 
         var mutexName = Path.GetFullPath(path).Replace(Path.DirectorySeparatorChar, ':') + MutexNameSuffix;
         _mutex = new Mutex(false, mutexName);
-        _underlyingStream = System.IO.File.Open(path, FileMode.Append, FileAccess.Write, FileShare.ReadWrite);
+        _underlyingStream = System.IO.File.Open(path, FileMode.Append, FileAccess.Write, FileShare.ReadWrite | FileShare.Delete);
         _output = new StreamWriter(_underlyingStream, encoding ?? new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
     }
 
@@ -92,6 +93,13 @@ public sealed class SharedFileSink : IFileSink, IDisposable, ISetLoggingFailureL
 
             try
             {
+                if (!System.IO.File.Exists(_path))
+                {
+                    _underlyingStream.Dispose();
+                    _underlyingStream = System.IO.File.Open(_path, FileMode.Append, FileAccess.Write, FileShare.ReadWrite | FileShare.Delete);
+                    _output = new StreamWriter(_underlyingStream,  new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+                }
+
                 _underlyingStream.Seek(0, SeekOrigin.End);
                 if (_fileSizeLimitBytes != null)
                 {

--- a/src/Serilog.Sinks.File/Sinks/File/SharedFileSink.OSMutex.cs
+++ b/src/Serilog.Sinks.File/Sinks/File/SharedFileSink.OSMutex.cs
@@ -97,17 +97,21 @@ public sealed class SharedFileSink : IFileSink, IDisposable, ISetLoggingFailureL
             {
                 if (!System.IO.File.Exists(_path))
                 {
-                    _output.Dispose();
-                    _underlyingStream.Dispose();
-                    _underlyingStream = System.IO.File.Open(_path, FileMode.Append, FileAccess.Write, FileShare.ReadWrite | FileShare.Delete);
-                    _output = new StreamWriter(_underlyingStream, _encoding ?? new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+                    ReopenOutputStream();
                 }
 
                 _underlyingStream.Seek(0, SeekOrigin.End);
                 if (_fileSizeLimitBytes != null)
                 {
-                    if (_underlyingStream.Length >= _fileSizeLimitBytes.Value)
-                        return false;
+                    try
+                    {
+                        if (_underlyingStream.Length >= _fileSizeLimitBytes.Value)
+                            return false;
+                    }
+                    catch (FileNotFoundException)
+                    {
+                        ReopenOutputStream();
+                    }
                 }
 
                 _textFormatter.Format(logEvent, _output);
@@ -190,6 +194,25 @@ public sealed class SharedFileSink : IFileSink, IDisposable, ISetLoggingFailureL
     void ReleaseMutex()
     {
         _mutex.ReleaseMutex();
+    }
+
+    void ReopenOutputStream()
+    {
+        var oldOutput = _output;
+        var oldStream = _underlyingStream;
+
+        _underlyingStream = System.IO.File.Open(_path, FileMode.Append, FileAccess.Write, FileShare.ReadWrite | FileShare.Delete);
+        _output = new StreamWriter(_underlyingStream, _encoding ?? new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
+        try
+        {
+            oldOutput.Dispose();
+            oldStream.Dispose();
+        }
+        catch (Exception ex) when (ex is IOException or ObjectDisposedException)
+        {
+            SelfLog.WriteLine("error while disposing replaced shared-file writer/stream: {0}", ex.Message);
+        }
     }
 
     void ISetLoggingFailureListener.SetFailureListener(ILoggingFailureListener failureListener)

--- a/test/Serilog.Sinks.File.Tests/FileSinkTests.cs
+++ b/test/Serilog.Sinks.File.Tests/FileSinkTests.cs
@@ -1,4 +1,4 @@
-using Serilog.Core;
+﻿using Serilog.Core;
 using Serilog.Events;
 using Serilog.Formatting.Json;
 using Serilog.Sinks.File.Tests.Support;
@@ -256,6 +256,35 @@ public class FileSinkTests
             lines = ReadAllLinesShared(path);
             Assert.Equal(3, lines.Length);
         }
+    }
+
+    [Fact]
+    public void FileIsReWrittenAfterEventIfDeleted()
+    {
+        using var tmp = TempFolder.ForCaller();
+        var nonexistent = tmp.AllocateFilename("txt");
+        var evt = Some.LogEvent("Hello, world!");
+
+        void Emmit()
+        {
+            using var sink = new FileSink(nonexistent, new JsonFormatter(), null);
+            sink.Emit(evt);
+        }
+
+        Emmit();
+        var lines = System.IO.File.ReadAllLines(nonexistent);
+        Assert.Contains("Hello, world!", lines[0]);
+        Assert.Single(lines);
+
+        System.IO.File.Delete(nonexistent);
+        Assert.False(System.IO.File.Exists(nonexistent));
+        Assert.Throws<FileNotFoundException>(() => System.IO.File.ReadAllLines(nonexistent));
+
+        Emmit();
+        lines = System.IO.File.ReadAllLines(nonexistent);
+        Assert.True(System.IO.File.Exists(nonexistent));
+        Assert.Contains("Hello, world!", lines[0]);
+        Assert.Single(lines);
     }
 
     static void WriteTwoEventsAndCheckOutputFileLength(long? maxBytes, Encoding encoding)

--- a/test/Serilog.Sinks.File.Tests/FileSinkTests.cs
+++ b/test/Serilog.Sinks.File.Tests/FileSinkTests.cs
@@ -265,13 +265,13 @@ public class FileSinkTests
         var nonexistent = tmp.AllocateFilename("txt");
         var evt = Some.LogEvent("Hello, world!");
 
-        void Emmit()
+        void Emit()
         {
             using var sink = new FileSink(nonexistent, new JsonFormatter(), null);
             sink.Emit(evt);
         }
 
-        Emmit();
+        Emit();
         var lines = System.IO.File.ReadAllLines(nonexistent);
         Assert.Contains("Hello, world!", lines[0]);
         Assert.Single(lines);
@@ -280,7 +280,7 @@ public class FileSinkTests
         Assert.False(System.IO.File.Exists(nonexistent));
         Assert.Throws<FileNotFoundException>(() => System.IO.File.ReadAllLines(nonexistent));
 
-        Emmit();
+        Emit();
         lines = System.IO.File.ReadAllLines(nonexistent);
         Assert.True(System.IO.File.Exists(nonexistent));
         Assert.Contains("Hello, world!", lines[0]);

--- a/test/Serilog.Sinks.File.Tests/RollingFileSinkTests.cs
+++ b/test/Serilog.Sinks.File.Tests/RollingFileSinkTests.cs
@@ -373,6 +373,73 @@ public class RollingFileSinkTests : IDisposable
             Directory.Delete(temp, true);
         }
     }
+        [Fact]
+        public void ShouldReCreateDeletedFiles()
+        {
+            var fileName = Some.String() + "-{Date}.txt";
+            var temp = Some.TempFolderPath();
+            var folder = Path.Combine(temp, Guid.NewGuid().ToString());
+            var pathFormat = Path.Combine(folder, fileName);
+
+            Logger? log = null;
+
+            try
+            {
+                log = new LoggerConfiguration()
+                    .WriteTo.File(pathFormat, rollingInterval: RollingInterval.Day, shared:true)
+                    .CreateLogger();
+
+                log.Write(Some.InformationEvent());
+                Assert.True(Directory.Exists(folder));
+
+                var createdFile = Directory.GetFiles(folder)[0];
+                System.IO.File.Delete(createdFile);
+                Assert.False(System.IO.File.Exists(createdFile));
+
+                log = new LoggerConfiguration()
+                    .WriteTo.File(pathFormat, rollingInterval: RollingInterval.Day, shared: true)
+                    .CreateLogger();
+
+                log.Write(Some.InformationEvent());
+                Assert.True(System.IO.File.Exists(createdFile));
+            }
+            finally
+            {
+                log?.Dispose();
+                Directory.Delete(temp, true);
+            }
+        }
+
+        [Fact]
+        public void ShouldBeAbleToDeleteFile()
+        {
+            var fileName = Some.String() + "-{Date}.txt";
+            var temp = Some.TempFolderPath();
+            var folder = Path.Combine(temp, Guid.NewGuid().ToString());
+            var pathFormat = Path.Combine(folder, fileName);
+
+            Logger? log = null;
+
+            try
+            {
+                log = new LoggerConfiguration()
+                    .WriteTo.File(pathFormat, retainedFileCountLimit: 3, rollingInterval: RollingInterval.Day,
+                        shared:true, flushToDiskInterval:TimeSpan.FromSeconds(1), buffered:false)
+                    .CreateLogger();
+
+                log.Write(Some.InformationEvent());
+                Assert.True(Directory.Exists(folder));
+
+                var createdFile = Directory.GetFiles(folder)[0];
+                System.IO.File.Delete(createdFile);
+                Assert.False(System.IO.File.Exists(createdFile));
+            }
+            finally
+            {
+                log?.Dispose();
+                Directory.Delete(temp, true);
+            }
+        }
 
     static void TestRollingEventSequence(params LogEvent[] events)
     {

--- a/test/Serilog.Sinks.File.Tests/RollingFileSinkTests.cs
+++ b/test/Serilog.Sinks.File.Tests/RollingFileSinkTests.cs
@@ -396,6 +396,8 @@ public class RollingFileSinkTests : IDisposable
                 System.IO.File.Delete(createdFile);
                 Assert.False(System.IO.File.Exists(createdFile));
 
+                log.Dispose();
+
                 log = new LoggerConfiguration()
                     .WriteTo.File(pathFormat, rollingInterval: RollingInterval.Day, shared: true)
                     .CreateLogger();
@@ -439,6 +441,45 @@ public class RollingFileSinkTests : IDisposable
                 log?.Dispose();
                 Directory.Delete(temp, true);
             }
+        }
+
+        [Fact]
+        public void ShouldReCreateDeletedFilesWithoutRecreatingLogger()
+        {
+            var fileName = Some.String() + "-{Date}.txt";
+            var temp = Some.TempFolderPath();
+            var folder = Path.Combine(temp, Guid.NewGuid().ToString());
+            var pathFormat = Path.Combine(folder, fileName);
+
+            Logger? log = null;
+
+            try
+            {
+                log = new LoggerConfiguration()
+                    .WriteTo.File(pathFormat, rollingInterval: RollingInterval.Day, shared: true, buffered: false)
+                    .CreateLogger();
+
+                log.Write(Some.LogEvent("first"));
+
+                var createdFile = Directory.GetFiles(folder)[0];
+                System.IO.File.Delete(createdFile);
+                Assert.False(System.IO.File.Exists(createdFile));
+
+                log.Write(Some.LogEvent("second"));
+
+                Assert.True(System.IO.File.Exists(createdFile));
+            }
+            finally
+            {
+                log?.Dispose();
+            }
+
+            var recreatedFile = Directory.GetFiles(folder)[0];
+            var lines = System.IO.File.ReadAllLines(recreatedFile);
+            Assert.Single(lines);
+            Assert.Contains("second", lines[0]);
+
+            Directory.Delete(temp, true);
         }
 
     static void TestRollingEventSequence(params LogEvent[] events)

--- a/test/Serilog.Sinks.File.Tests/SharedFileSinkTests.cs
+++ b/test/Serilog.Sinks.File.Tests/SharedFileSinkTests.cs
@@ -2,6 +2,7 @@
 using Xunit;
 using Serilog.Formatting.Json;
 using Serilog.Sinks.File.Tests.Support;
+using System.Text;
 
 #pragma warning disable 618
 
@@ -121,5 +122,104 @@ public class SharedFileSinkTests
         Assert.True(System.IO.File.Exists(nonexistent));
         Assert.Contains("Hello, world!", lines[0]);
         Assert.Single(lines);
+    }
+
+    [Fact]
+    public void FileIsReWrittenAfterEventIfDeletedWithoutRecreatingSink()
+    {
+        using var tmp = TempFolder.ForCaller();
+        var path = tmp.AllocateFilename("txt");
+
+        using (var sink = new SharedFileSink(path, new JsonFormatter(), null))
+        {
+            sink.Emit(Some.LogEvent("First event"));
+
+            System.IO.File.Delete(path);
+            Assert.False(System.IO.File.Exists(path));
+
+            sink.Emit(Some.LogEvent("Second event"));
+            Assert.True(System.IO.File.Exists(path));
+        }
+
+        var lines = System.IO.File.ReadAllLines(path);
+        Assert.Single(lines);
+        Assert.Contains("Second event", lines[0]);
+    }
+
+    [Fact]
+    public void FileIsReWrittenAfterEventIfDeletedWithoutRecreatingSinkWhenLimitIsSpecified()
+    {
+        using var tmp = TempFolder.ForCaller();
+        var path = tmp.AllocateFilename("txt");
+
+        using (var sink = new SharedFileSink(path, new JsonFormatter(), 4096))
+        {
+            sink.Emit(Some.LogEvent("First event"));
+
+            System.IO.File.Delete(path);
+            Assert.False(System.IO.File.Exists(path));
+
+            sink.Emit(Some.LogEvent("Second event"));
+            Assert.True(System.IO.File.Exists(path));
+        }
+
+        var lines = System.IO.File.ReadAllLines(path);
+        Assert.Single(lines);
+        Assert.Contains("Second event", lines[0]);
+    }
+
+    [Fact]
+    public void EncodingIsPreservedAfterDeleteAndRecreateWithoutRecreatingSink()
+    {
+        using var tmp = TempFolder.ForCaller();
+        var path = tmp.AllocateFilename("txt");
+        var encoding = Encoding.Unicode;
+
+        using (var sink = new SharedFileSink(path, new JsonFormatter(), null, encoding))
+        {
+            sink.Emit(Some.LogEvent("First event"));
+
+            System.IO.File.Delete(path);
+            Assert.False(System.IO.File.Exists(path));
+
+            sink.Emit(Some.LogEvent("Second event ç"));
+            Assert.True(System.IO.File.Exists(path));
+        }
+
+        var bytes = System.IO.File.ReadAllBytes(path);
+        Assert.True(bytes.AsSpan().StartsWith(encoding.GetPreamble()));
+
+        var text = encoding.GetString(bytes);
+        Assert.Contains("Second event ç", text);
+        Assert.DoesNotContain("First event", text);
+    }
+
+    [Fact]
+    public void EncodingIsPreservedAfterDeleteAndRecreateWithRecreatingSink()
+    {
+        using var tmp = TempFolder.ForCaller();
+        var path = tmp.AllocateFilename("txt");
+        var encoding = Encoding.Unicode;
+
+        void EmitWithNewSink(string message)
+        {
+            using var sink = new SharedFileSink(path, new JsonFormatter(), null, encoding);
+            sink.Emit(Some.LogEvent(message));
+        }
+
+        EmitWithNewSink("First event");
+
+        System.IO.File.Delete(path);
+        Assert.False(System.IO.File.Exists(path));
+
+        EmitWithNewSink("Second event ç");
+        Assert.True(System.IO.File.Exists(path));
+
+        var bytes = System.IO.File.ReadAllBytes(path);
+        Assert.True(bytes.AsSpan().StartsWith(encoding.GetPreamble()));
+
+        var text = encoding.GetString(bytes);
+        Assert.Contains("Second event ç", text);
+        Assert.DoesNotContain("First event", text);
     }
 }

--- a/test/Serilog.Sinks.File.Tests/SharedFileSinkTests.cs
+++ b/test/Serilog.Sinks.File.Tests/SharedFileSinkTests.cs
@@ -222,4 +222,100 @@ public class SharedFileSinkTests
         Assert.Contains("Second event ç", text);
         Assert.DoesNotContain("First event", text);
     }
+
+    [Fact]
+    public void FileDeletionDuringWriteOperationIsHandledGracefully()
+    {
+        // Test that when a file is deleted between checking its existence and writing to it,
+        // the sink gracefully reopens the file and retries the write operation.
+        using var tmp = TempFolder.ForCaller();
+        var path = tmp.AllocateFilename("txt");
+
+        using (var sink = new SharedFileSink(path, new JsonFormatter(), null))
+        {
+            var evt1 = Some.LogEvent("Event 1");
+            sink.Emit(evt1);
+            Assert.True(System.IO.File.Exists(path));
+
+            // Delete the file while the sink is still open
+            System.IO.File.Delete(path);
+            Assert.False(System.IO.File.Exists(path));
+
+            // Emit another event - this should trigger ReopenOutputStream and succeed
+            var evt2 = Some.LogEvent("Event 2");
+            sink.Emit(evt2);
+            Assert.True(System.IO.File.Exists(path));
+        }
+
+        // Verify the second event was written to the recreated file
+        var lines = System.IO.File.ReadAllLines(path);
+        Assert.Single(lines);
+        Assert.Contains("Event 2", lines[0]);
+    }
+
+    [Fact]
+    public void FileEncodingIsPreservedAfterDeletionAndRecreation()
+    {
+        // Test that encoding is preserved when a file is deleted and recreated during write operations.
+        using var tmp = TempFolder.ForCaller();
+        var path = tmp.AllocateFilename("txt");
+        var encoding = Encoding.Unicode;
+
+        using (var sink = new SharedFileSink(path, new JsonFormatter(), null, encoding))
+        {
+            var evt1 = Some.LogEvent("Event with special chars: é à ç");
+            sink.Emit(evt1);
+            sink.FlushToDisk();
+            Assert.True(System.IO.File.Exists(path));
+
+            // Delete the file
+            System.IO.File.Delete(path);
+            Assert.False(System.IO.File.Exists(path));
+
+            // Emit another event with special characters - encoding should be preserved
+            var evt2 = Some.LogEvent("Second event with ñ");
+            sink.Emit(evt2);
+            sink.FlushToDisk();
+            Assert.True(System.IO.File.Exists(path));
+        }
+
+        // Read after sink is disposed
+        var bytes = System.IO.File.ReadAllBytes(path);
+        Assert.True(bytes.AsSpan().StartsWith(encoding.GetPreamble()), "Encoding preamble should be present after recreation");
+
+        var text = encoding.GetString(bytes);
+        Assert.Contains("Second event with ñ", text);
+    }
+
+    [Fact]
+    public void MultipleDeletionAndRecreationCyclesAreHandled()
+    {
+        // Test that multiple file deletion/recreation cycles don't cause resource leaks.
+        using var tmp = TempFolder.ForCaller();
+        var path = tmp.AllocateFilename("txt");
+
+        using (var sink = new SharedFileSink(path, new JsonFormatter(), null))
+        {
+            for (int i = 0; i < 5; i++)
+            {
+                var evt = Some.LogEvent($"Event {i + 1}");
+                sink.Emit(evt);
+                Assert.True(System.IO.File.Exists(path));
+
+                // Delete and recreate cycle
+                System.IO.File.Delete(path);
+                Assert.False(System.IO.File.Exists(path));
+            }
+
+            // Final emit after multiple cycles
+            var finalEvt = Some.LogEvent("Final event");
+            sink.Emit(finalEvt);
+            Assert.True(System.IO.File.Exists(path));
+        }
+
+        // Verify the final event was written
+        var lines = System.IO.File.ReadAllLines(path);
+        Assert.Single(lines);
+        Assert.Contains("Final event", lines[0]);
+    }
 }

--- a/test/Serilog.Sinks.File.Tests/SharedFileSinkTests.cs
+++ b/test/Serilog.Sinks.File.Tests/SharedFileSinkTests.cs
@@ -102,13 +102,7 @@ public class SharedFileSinkTests
         var nonexistent = tmp.AllocateFilename("txt");
         var evt = Some.LogEvent("Hello, world!");
 
-        void Emmit()
-        {
-            using var sink = new SharedFileSink(nonexistent, new JsonFormatter(), null);
-            sink.Emit(evt);
-        }
-
-        Emmit();
+        Emit();
         var lines = System.IO.File.ReadAllLines(nonexistent);
         Assert.Contains("Hello, world!", lines[0]);
         Assert.Single(lines);
@@ -117,11 +111,17 @@ public class SharedFileSinkTests
         Assert.False(System.IO.File.Exists(nonexistent));
         Assert.Throws<FileNotFoundException>(() => System.IO.File.ReadAllLines(nonexistent));
 
-        Emmit();
+        Emit();
         lines = System.IO.File.ReadAllLines(nonexistent);
         Assert.True(System.IO.File.Exists(nonexistent));
         Assert.Contains("Hello, world!", lines[0]);
         Assert.Single(lines);
+
+        void Emit()
+        {
+            using var sink = new SharedFileSink(nonexistent, new JsonFormatter(), null);
+            sink.Emit(evt);
+        }
     }
 
     [Fact]

--- a/test/Serilog.Sinks.File.Tests/SharedFileSinkTests.cs
+++ b/test/Serilog.Sinks.File.Tests/SharedFileSinkTests.cs
@@ -94,4 +94,32 @@ public class SharedFileSinkTests
         var size = new FileInfo(path).Length;
         Assert.True(size > maxBytes * 2);
     }
+    [Fact]
+    public void FileIsReWrittenAfterEventIfDeleted()
+    {
+        using var tmp = TempFolder.ForCaller();
+        var nonexistent = tmp.AllocateFilename("txt");
+        var evt = Some.LogEvent("Hello, world!");
+
+        void Emmit()
+        {
+            using var sink = new SharedFileSink(nonexistent, new JsonFormatter(), null);
+            sink.Emit(evt);
+        }
+
+        Emmit();
+        var lines = System.IO.File.ReadAllLines(nonexistent);
+        Assert.Contains("Hello, world!", lines[0]);
+        Assert.Single(lines);
+
+        System.IO.File.Delete(nonexistent);
+        Assert.False(System.IO.File.Exists(nonexistent));
+        Assert.Throws<FileNotFoundException>(() => System.IO.File.ReadAllLines(nonexistent));
+
+        Emmit();
+        lines = System.IO.File.ReadAllLines(nonexistent);
+        Assert.True(System.IO.File.Exists(nonexistent));
+        Assert.Contains("Hello, world!", lines[0]);
+        Assert.Single(lines);
+    }
 }


### PR DESCRIPTION
As discussed in #96 and #128, this gives the ability to delete files when is created by a SharedFileSink and recreates the rolling file when deleted.

This is my implementation for #144. Took me a while to be able to do some house cleaning and resume pending projects.
Also validated in runtime through the `sample` projects on linux-x64 and win-x64. 