### PR TITLE
Silence ObjectDisposedException race in PeriodicFlushToDiskSink

### DIFF
--- a/src/Serilog.Sinks.File/Sinks/File/PeriodicFlushToDiskSink.cs
+++ b/src/Serilog.Sinks.File/Sinks/File/PeriodicFlushToDiskSink.cs
@@ -89,10 +89,7 @@ public sealed class PeriodicFlushToDiskSink : ILogEventSink, IDisposable, ISetLo
         }
         catch (ObjectDisposedException)
         {
-            // Expected race against rolling/shutdown: the underlying sink was disposed between
-            // the timer firing and the flush call. Not an I/O failure; suppress to avoid spamming
-            // the failure listener (default: SelfLog). The next timer tick will flush the
-            // replacement sink cleanly.
+            // Avoid spamming failure listeners when rolling to a new file.
         }
         catch (Exception ex)
         {

--- a/src/Serilog.Sinks.File/Sinks/File/PeriodicFlushToDiskSink.cs
+++ b/src/Serilog.Sinks.File/Sinks/File/PeriodicFlushToDiskSink.cs
@@ -76,7 +76,7 @@ public sealed class PeriodicFlushToDiskSink : ILogEventSink, IDisposable, ISetLo
         (_sink as IDisposable)?.Dispose();
     }
 
-    void FlushToDisk(IFlushableFileSink flushable)
+    internal void FlushToDisk(IFlushableFileSink flushable)
     {
         try
         {
@@ -86,6 +86,13 @@ public sealed class PeriodicFlushToDiskSink : ILogEventSink, IDisposable, ISetLo
                 // anything here in the wrapper.
                 flushable.FlushToDisk();
             }
+        }
+        catch (ObjectDisposedException)
+        {
+            // Expected race against rolling/shutdown: the underlying sink was disposed between
+            // the timer firing and the flush call. Not an I/O failure; suppress to avoid spamming
+            // the failure listener (default: SelfLog). The next timer tick will flush the
+            // replacement sink cleanly.
         }
         catch (Exception ex)
         {

--- a/test/Serilog.Sinks.File.Tests/PeriodicFlushToDiskSinkTests.cs
+++ b/test/Serilog.Sinks.File.Tests/PeriodicFlushToDiskSinkTests.cs
@@ -1,0 +1,93 @@
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Sinks.File.Tests.Support;
+using Xunit;
+
+#pragma warning disable 618 // PeriodicFlushToDiskSink is marked obsolete; we still test it directly.
+
+namespace Serilog.Sinks.File.Tests;
+
+public class PeriodicFlushToDiskSinkTests
+{
+    [Fact]
+    public void FlushToDisk_WhenFlushableThrowsObjectDisposed_SuppressesFailureReport()
+    {
+        var flushable = new StubFlushable(() => new ObjectDisposedException("FileStream"));
+        var listener = new RecordingFailureListener();
+        using var sink = new PeriodicFlushToDiskSink(flushable, Timeout.InfiniteTimeSpan);
+        ((ISetLoggingFailureListener)sink).SetFailureListener(listener);
+
+        sink.Emit(Some.InformationEvent());
+        sink.FlushToDisk(flushable);
+
+        Assert.Empty(listener.Failures);
+        Assert.Equal(1, flushable.FlushCount);
+    }
+
+    [Fact]
+    public void FlushToDisk_WhenFlushableThrowsIOException_ReportsAsTemporaryFailure()
+    {
+        var ioException = new IOException("disk full");
+        var flushable = new StubFlushable(() => ioException);
+        var listener = new RecordingFailureListener();
+        using var sink = new PeriodicFlushToDiskSink(flushable, Timeout.InfiniteTimeSpan);
+        ((ISetLoggingFailureListener)sink).SetFailureListener(listener);
+
+        sink.Emit(Some.InformationEvent());
+        sink.FlushToDisk(flushable);
+
+        var failure = Assert.Single(listener.Failures);
+        Assert.Equal(LoggingFailureKind.Temporary, failure.Kind);
+        Assert.Same(ioException, failure.Exception);
+    }
+
+    [Fact]
+    public void FlushToDisk_WhenNoEventEmitted_DoesNotInvokeUnderlyingFlush()
+    {
+        var flushable = new StubFlushable();
+        var listener = new RecordingFailureListener();
+        using var sink = new PeriodicFlushToDiskSink(flushable, Timeout.InfiniteTimeSpan);
+        ((ISetLoggingFailureListener)sink).SetFailureListener(listener);
+
+        sink.FlushToDisk(flushable);
+
+        Assert.Equal(0, flushable.FlushCount);
+        Assert.Empty(listener.Failures);
+    }
+
+    sealed class StubFlushable : ILogEventSink, IFlushableFileSink
+    {
+        readonly Func<Exception?>? _onFlush;
+
+        public StubFlushable(Func<Exception?>? onFlush = null)
+        {
+            _onFlush = onFlush;
+        }
+
+        public int FlushCount;
+
+        public void Emit(LogEvent logEvent)
+        {
+        }
+
+        public void FlushToDisk()
+        {
+            FlushCount++;
+            var exception = _onFlush?.Invoke();
+            if (exception != null)
+            {
+                throw exception;
+            }
+        }
+    }
+
+    sealed class RecordingFailureListener : ILoggingFailureListener
+    {
+        public List<(LoggingFailureKind Kind, string Message, Exception? Exception)> Failures { get; } = [];
+
+        public void OnLoggingFailed(object sender, LoggingFailureKind kind, string message, IReadOnlyCollection<LogEvent>? events, Exception? exception)
+        {
+            Failures.Add((kind, message, exception));
+        }
+    }
+}


### PR DESCRIPTION
Closes #367.

## Background

`PeriodicFlushToDiskSink.FlushToDisk` runs on a `Timer` independent of `RollingFileSink`'s roll lifecycle. When a roll closes the active `FileSink` and opens a new one, the timer can fire in between and catch the disposed instance. Today this is caught by the generic `catch (Exception)` branch and reported as a `Temporary` failure through `ILoggingFailureListener` (default: `SelfLog`), once per `flushToDiskInterval` per roll, indefinitely.

The race itself is already documented inline in the source:

```csharp
// May throw ObjectDisposedException, since we're not trying to synchronize
// anything here in the wrapper.
flushable.FlushToDisk();
```

## Change

Add a dedicated `catch (ObjectDisposedException)` clause before the generic one and suppress. Real I/O failures (`IOException`, `UnauthorizedAccessException`, etc.) still flow through the existing `Temporary` failure path.

`FlushToDisk(IFlushableFileSink)` is promoted from implicit `private` to `internal` so the new tests in `Serilog.Sinks.File.Tests` (already wired through `InternalsVisibleTo` in `AssemblyInfo.cs`) can drive it deterministically without relying on `Timer` wall-clock cadence. No public API surface changes.

## Why this is safe

- `ObjectDisposedException` at this site can only originate from the underlying `FlushToDisk()` call on a disposed `FileSink`. There is no other shared state on the path.
- The next timer tick picks up the new `FileSink` and flushes cleanly. No data loss.
- Behaviour is unchanged for any other exception type.

## Tests

Three new tests in `PeriodicFlushToDiskSinkTests`:

- `FlushToDisk_WhenFlushableThrowsObjectDisposed_SuppressesFailureReport` - listener receives no `OnLoggingFailed` call when the underlying flush throws `ObjectDisposedException`.
- `FlushToDisk_WhenFlushableThrowsIOException_ReportsAsTemporaryFailure` - listener still receives the exception as `Temporary` failure when the underlying flush throws `IOException`.
- `FlushToDisk_WhenNoEventEmitted_DoesNotInvokeUnderlyingFlush` - guards the existing `_flushRequired` short-circuit.

Tests pass on `net48`, `net8.0`, `net9.0` (3 / 3 each).

## Downstream impact

Real-world case from a downstream telemetry pipeline that tees `SelfLog` into a diagnostic file: 22 155 / 88 786 lines (~25 %) of the operator-visible diagnostics file were this single exception. A second deployment saw closer to 50 %. A local downstream filter mitigates the noise for that pipeline, but fixing upstream removes it for every consumer of `Serilog.Sinks.File` whose listener persists or surfaces `Temporary` failures.